### PR TITLE
geometry extensions

### DIFF
--- a/Chroma/ChromaController.cs
+++ b/Chroma/ChromaController.cs
@@ -34,6 +34,8 @@ namespace Chroma
         internal const string V2_LOCAL_POSITION = "_localPosition";
 
         internal const string V2_ENVIRONMENT = "_environment";
+        internal const string V2_GEOMETRY = "_geometry";
+        internal const string V2_GEOMETRY_TYPE = "_geometryType";
         internal const string V2_GAMEOBJECT_ID = "_id";
         internal const string V2_LOOKUP_METHOD = "_lookupMethod";
         internal const string V2_DUPLICATION_AMOUNT = "_duplicate";
@@ -57,6 +59,8 @@ namespace Chroma
         internal const string RING_ROTATION = "rotation";
 
         internal const string ENVIRONMENT = "environment";
+        internal const string GEOMETRY = "geometry";
+        internal const string GEOMETRY_TYPE = "geometryType";
         internal const string GAMEOBJECT_ID = "id";
         internal const string LOOKUP_METHOD = "lookupMethod";
         internal const string DUPLICATION_AMOUNT = "duplicate";

--- a/Chroma/HeckImplementation/CustomDataManager.cs
+++ b/Chroma/HeckImplementation/CustomDataManager.cs
@@ -23,9 +23,22 @@ namespace Chroma
         {
             bool v2 = beatmapData.version2_6_0AndEarlier;
             IEnumerable<CustomData>? environmentData = beatmapData.customData.Get<List<object>>(v2 ? V2_ENVIRONMENT : ENVIRONMENT)?.Cast<CustomData>();
+            IEnumerable<CustomData>? geometriesData = beatmapData.customData.Get<List<object>>(v2 ? V2_GEOMETRY : GEOMETRY)?.Cast<CustomData>();
             if (environmentData != null)
             {
                 foreach (CustomData gameObjectData in environmentData)
+                {
+                    string? trackName = gameObjectData.Get<string>(v2 ? V2_TRACK : TRACK);
+                    if (trackName != null)
+                    {
+                        trackBuilder.AddTrack(trackName);
+                    }
+                }
+            }
+
+            if (geometriesData != null)
+            {
+                foreach (CustomData gameObjectData in geometriesData)
                 {
                     string? trackName = gameObjectData.Get<string>(v2 ? V2_TRACK : TRACK);
                     if (trackName != null)


### PR DESCRIPTION
Not tested:tm:

This adds the following properties to the BEATMAP difficulty custom data:
```jsonc
"_customData": {
  "_environment": {.....},
  "_geometry": {[
  {
  // localPosition, position, scale, localRotation, rotation
  // scale defaults to 1
  // Position and localPosition use Noodle Units in v2 maps, may change
  "_track": "MyTrack",
  "_color": [1, 1, 1], // by default is color cyan for debugging purposes
  "_geometryType": "SPHERE/CAPSULE/CYLINDER/CUBE/PLANE/QUAD"
  }
]}
```


Currently uses Unity's Standard material, may change to use the BTS cube's Material/Shader for consistency and bloom support.
Should also mention that this shader MAY or MAY NOT be stripped on Quest, further reasoning to use a basegame shader.

This is an implementation based on cals' #52 issue.