### PR TITLE
Standalone device control

### DIFF
--- a/NoodleExtensions/Animation/EventController.cs
+++ b/NoodleExtensions/Animation/EventController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using CustomJSONData.CustomBeatmap;
 using Heck;
 using JetBrains.Annotations;

--- a/NoodleExtensions/Animation/PlayerTrack.cs
+++ b/NoodleExtensions/Animation/PlayerTrack.cs
@@ -221,40 +221,20 @@ namespace NoodleExtensions.Animation
 
             public PlayerTrack Create(PlayerTrackObject playerTrackObject)
             {
-                GameObject noodleObject = new("NoodlePlayerTrack");
+                GameObject noodleObject = new($"NoodlePlayerTrack{playerTrackObject}");
                 Transform origin = noodleObject.transform;
 
-                switch (playerTrackObject)
+                Transform target = playerTrackObject switch
                 {
-                    case PlayerTrackObject.ENTIRE_PLAYER:
-                    {
-                        Transform player = GameObject.Find("LocalPlayerGameCore").transform;
-                        origin.SetParent(player.parent, true);
-                        player.SetParent(origin, true);
-                        break;
-                    }
+                    PlayerTrackObject.ENTIRE_PLAYER => GameObject.Find("LocalPlayerGameCore").transform,
+                    PlayerTrackObject.HMD => GameObject.Find("VRGameCore/MainCamera").transform,
+                    PlayerTrackObject.LEFT_HAND => GameObject.Find("VRGameCore/LeftHand").transform,
+                    PlayerTrackObject.RIGHT_HAND => GameObject.Find("VRGameCore/RightHand").transform,
+                    _ => throw new ArgumentOutOfRangeException(nameof(playerTrackObject), playerTrackObject, null)
+                };
 
-                    case PlayerTrackObject.HMD:
-                        Transform hmd = GameObject.Find("VRGameCore/MainCamera").transform;
-                        origin.SetParent(hmd.parent, true);
-                        hmd.SetParent(origin, true);
-                        break;
-
-                    // TODO: Figure out the right name for these objects
-                    // just placeholder
-                    case PlayerTrackObject.LEFT_HAND:
-                        Transform leftController = GameObject.Find("VRGameCore/LeftHand").transform;
-                        origin.SetParent(leftController.parent, true);
-                        leftController.SetParent(origin, true);
-                        break;
-                    case PlayerTrackObject.RIGHT_HAND:
-                        Transform rightController = GameObject.Find("VRGameCore/RightHand").transform;
-                        origin.SetParent(rightController.parent, true);
-                        rightController.SetParent(origin, true);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(playerTrackObject), playerTrackObject, null);
-                }
+                origin.SetParent(target.parent, true);
+                target.SetParent(origin, true);
 
                 return _container.InstantiateComponent<PlayerTrack>(noodleObject);
             }

--- a/NoodleExtensions/Animation/PlayerTrack.cs
+++ b/NoodleExtensions/Animation/PlayerTrack.cs
@@ -210,7 +210,7 @@ namespace NoodleExtensions.Animation
         }
 
         [UsedImplicitly]
-        internal class PlayerTrackFactory : IFactory<PlayerTrackObject, PlayerTrack>
+        internal class PlayerTrackFactory : PlaceholderFactory<PlayerTrackObject, PlayerTrack>
         {
             private readonly IInstantiator _container;
 

--- a/NoodleExtensions/Animation/PlayerTrack.cs
+++ b/NoodleExtensions/Animation/PlayerTrack.cs
@@ -2,6 +2,7 @@
 using Heck;
 using Heck.Animation;
 using Heck.Animation.Transform;
+using IPA.Utilities;
 using JetBrains.Annotations;
 using UnityEngine;
 using Zenject;
@@ -10,6 +11,14 @@ using static NoodleExtensions.NoodleController;
 
 namespace NoodleExtensions.Animation
 {
+    internal enum PlayerTrackObject
+    {
+        ENTIRE_PLAYER,
+        HMD,
+        LEFT_HAND,
+        RIGHT_HAND
+    }
+
     internal class PlayerTrack : MonoBehaviour
     {
         // because camera2 is cringe
@@ -201,7 +210,7 @@ namespace NoodleExtensions.Animation
         }
 
         [UsedImplicitly]
-        internal class PlayerTrackFactory : IFactory<PlayerTrack>
+        internal class PlayerTrackFactory : IFactory<PlayerTrackObject, PlayerTrack>
         {
             private readonly IInstantiator _container;
 
@@ -210,13 +219,43 @@ namespace NoodleExtensions.Animation
                 _container = container;
             }
 
-            public PlayerTrack Create()
+            public PlayerTrack Create(PlayerTrackObject playerTrackObject)
             {
-                Transform player = GameObject.Find("LocalPlayerGameCore").transform;
                 GameObject noodleObject = new("NoodlePlayerTrack");
                 Transform origin = noodleObject.transform;
-                origin.SetParent(player.parent, true);
-                player.SetParent(origin, true);
+
+                switch (playerTrackObject)
+                {
+                    case PlayerTrackObject.ENTIRE_PLAYER:
+                    {
+                        Transform player = GameObject.Find("LocalPlayerGameCore").transform;
+                        origin.SetParent(player.parent, true);
+                        player.SetParent(origin, true);
+                        break;
+                    }
+
+                    case PlayerTrackObject.HMD:
+                        Transform hmd = GameObject.Find("VRGameCore/MainCamera").transform;
+                        origin.SetParent(hmd.parent, true);
+                        hmd.SetParent(origin, true);
+                        break;
+
+                    // TODO: Figure out the right name for these objects
+                    // just placeholder
+                    case PlayerTrackObject.LEFT_HAND:
+                        Transform leftController = GameObject.Find("VRGameCore/LeftController").transform;
+                        origin.SetParent(leftController.parent, true);
+                        leftController.SetParent(origin, true);
+                        break;
+                    case PlayerTrackObject.RIGHT_HAND:
+                        Transform rightController = GameObject.Find("VRGameCore/RightController").transform;
+                        origin.SetParent(rightController.parent, true);
+                        rightController.SetParent(origin, true);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(playerTrackObject), playerTrackObject, null);
+                }
+
                 return _container.InstantiateComponent<PlayerTrack>(noodleObject);
             }
         }

--- a/NoodleExtensions/Animation/PlayerTrack.cs
+++ b/NoodleExtensions/Animation/PlayerTrack.cs
@@ -243,12 +243,12 @@ namespace NoodleExtensions.Animation
                     // TODO: Figure out the right name for these objects
                     // just placeholder
                     case PlayerTrackObject.LEFT_HAND:
-                        Transform leftController = GameObject.Find("VRGameCore/LeftController").transform;
+                        Transform leftController = GameObject.Find("VRGameCore/LeftHand").transform;
                         origin.SetParent(leftController.parent, true);
                         leftController.SetParent(origin, true);
                         break;
                     case PlayerTrackObject.RIGHT_HAND:
-                        Transform rightController = GameObject.Find("VRGameCore/RightController").transform;
+                        Transform rightController = GameObject.Find("VRGameCore/RightHand").transform;
                         origin.SetParent(rightController.parent, true);
                         rightController.SetParent(origin, true);
                         break;

--- a/NoodleExtensions/Animation/PlayerTrack.cs
+++ b/NoodleExtensions/Animation/PlayerTrack.cs
@@ -1,4 +1,4 @@
-﻿using CustomJSONData.CustomBeatmap;
+using CustomJSONData.CustomBeatmap;
 using Heck;
 using Heck.Animation;
 using Heck.Animation.Transform;
@@ -6,6 +6,7 @@ using IPA.Utilities;
 using JetBrains.Annotations;
 using UnityEngine;
 using Zenject;
+using System;
 using static Heck.HeckController;
 using static NoodleExtensions.NoodleController;
 

--- a/NoodleExtensions/HeckImplementation/CustomDataTypes.cs
+++ b/NoodleExtensions/HeckImplementation/CustomDataTypes.cs
@@ -6,6 +6,7 @@ using Heck;
 using Heck.Animation;
 using Heck.Animation.Transform;
 using IPA.Utilities;
+using NoodleExtensions.Animation;
 using UnityEngine;
 using static Heck.HeckController;
 using static NoodleExtensions.NoodleController;
@@ -348,9 +349,14 @@ namespace NoodleExtensions
         {
             Track track = customData.GetTrack(tracks, v2);
             Track = track;
+
+            // DEFAULT TO PLAYER IF NOT SPECIFIED
+            PlayerTrackObject = customData.GetStringToEnum<PlayerTrackObject?>(v2 ? V2_PLAYER_TRACK_OBJECT : PLAYER_TRACK_OBJECT) ?? PlayerTrackObject.ENTIRE_PLAYER;
         }
 
         internal Track Track { get; }
+
+        internal PlayerTrackObject PlayerTrackObject { get; }
     }
 
     internal class NoodleParentTrackEventData : ICustomEventCustomData

--- a/NoodleExtensions/Installers/NoodlePlayerInstaller.cs
+++ b/NoodleExtensions/Installers/NoodlePlayerInstaller.cs
@@ -28,7 +28,7 @@ namespace NoodleExtensions.Installers
             // Events
             Container.BindInterfacesTo<EventController>().AsSingle();
             Container.Bind<ParentController>().AsSingle();
-            Container.BindIFactory<PlayerTrackObject, PlayerTrack, PlayerTrack.PlayerTrackFactory>().AsSingle();
+            Container.BindFactory<PlayerTrackObject, PlayerTrack, PlayerTrack.PlayerTrackFactory>().AsSingle();
             // Cutout
             Container.BindInterfacesTo<ObjectInitializer>().AsSingle();
 

--- a/NoodleExtensions/Installers/NoodlePlayerInstaller.cs
+++ b/NoodleExtensions/Installers/NoodlePlayerInstaller.cs
@@ -28,8 +28,7 @@ namespace NoodleExtensions.Installers
             // Events
             Container.BindInterfacesTo<EventController>().AsSingle();
             Container.Bind<ParentController>().AsSingle();
-            Container.Bind<PlayerTrack>().FromFactory<PlayerTrack.PlayerTrackFactory>().AsSingle();
-
+            Container.BindIFactory<PlayerTrackObject, PlayerTrack, PlayerTrack.PlayerTrackFactory>().AsSingle();
             // Cutout
             Container.BindInterfacesTo<ObjectInitializer>().AsSingle();
 

--- a/NoodleExtensions/NoodleController.cs
+++ b/NoodleExtensions/NoodleController.cs
@@ -25,6 +25,7 @@ namespace NoodleExtensions
         internal const string V2_WORLD_POSITION_STAYS = "_worldPositionStays";
         internal const string V2_PARENT_TRACK = "_parentTrack";
         internal const string V2_CHILDREN_TRACKS = "_childrenTracks";
+        internal const string V2_PLAYER_TRACK_OBJECT = "_playerTrackObject";
 
         internal const string NOTE_OFFSET = "coordinates";
         internal const string TAIL_NOTE_OFFSET = "tailCoordinates";
@@ -46,6 +47,7 @@ namespace NoodleExtensions
         internal const string WORLD_POSITION_STAYS = "worldPositionStays";
         internal const string PARENT_TRACK = "parentTrack";
         internal const string CHILDREN_TRACKS = "childrenTracks";
+        internal const string PLAYER_TRACK_OBJECT = "playerTrackObject";
 
         internal const string INTERNAL_STARTNOTELINELAYER = "NE_startNoteLineLayer";
         internal const string INTERNAL_TAILSTARTNOTELINELAYER = "NE_tailStartNoteLineLayer";


### PR DESCRIPTION
May rename fields to something more appropriate

Not fully tested

Adds a new field to `AssignPlayerToTrack`
```jsonc
"_data": {
  "_track": "MyTrack",
  "_playerTrackObject": "ENTIRE_PLAYER/HMD/LEFT_HAND/RIGHT_HAND" // When omitted, defaults to the old behaviour being `ENTIRE_PLAYER`
}
```