### PR TITLE
Environment materials (does not work on all environments)

### DIFF
--- a/Chroma/ChromaController.cs
+++ b/Chroma/ChromaController.cs
@@ -41,6 +41,7 @@ namespace Chroma
         internal const string V2_GEOMETRY_TYPE = "_type";
         internal const string V2_SHADER_PRESET = "_shader";
         internal const string V2_SHADER_KEYWORDS = "_shaderKeywords";
+        internal const string V2_ENVIRONMENT_MATERIAL = "_environmentMaterial";
         internal const string V2_COLLISION = "_collision";
         internal const string V2_MATERIALS = "_materials";
         internal const string V2_MATERIAL = "_material";
@@ -71,6 +72,7 @@ namespace Chroma
         internal const string GEOMETRY_TYPE = "type";
         internal const string SHADER_PRESET = "shader";
         internal const string SHADER_KEYWORDS = "shaderKeywords";
+        internal const string ENVIRONMENT_MATERIAL = "environmentMaterial";
         internal const string COLLISION = "collision";
         internal const string MATERIALS = "materials";
         internal const string MATERIAL = "material";

--- a/Chroma/ChromaController.cs
+++ b/Chroma/ChromaController.cs
@@ -41,7 +41,6 @@ namespace Chroma
         internal const string V2_GEOMETRY_TYPE = "_type";
         internal const string V2_SHADER_PRESET = "_shader";
         internal const string V2_SHADER_KEYWORDS = "_shaderKeywords";
-        internal const string V2_ENVIRONMENT_MATERIAL = "_environmentMaterial";
         internal const string V2_COLLISION = "_collision";
         internal const string V2_MATERIALS = "_materials";
         internal const string V2_MATERIAL = "_material";
@@ -72,7 +71,6 @@ namespace Chroma
         internal const string GEOMETRY_TYPE = "type";
         internal const string SHADER_PRESET = "shader";
         internal const string SHADER_KEYWORDS = "shaderKeywords";
-        internal const string ENVIRONMENT_MATERIAL = "environmentMaterial";
         internal const string COLLISION = "collision";
         internal const string MATERIALS = "materials";
         internal const string MATERIAL = "material";

--- a/Chroma/EnvironmentEnhancement/EnvironmentEnhancementManager.cs
+++ b/Chroma/EnvironmentEnhancement/EnvironmentEnhancementManager.cs
@@ -78,6 +78,7 @@ namespace Chroma.EnvironmentEnhancement
 
         private IEnumerator DelayedStart()
         {
+            yield return null; // Wait for material
             yield return new WaitForEndOfFrame();
 
             bool v2 = _beatmapData.version2_6_0AndEarlier;

--- a/Chroma/EnvironmentEnhancement/GeometryFactory.cs
+++ b/Chroma/EnvironmentEnhancement/GeometryFactory.cs
@@ -31,7 +31,8 @@ namespace Chroma.EnvironmentEnhancement
     {
         Standard,
         OpaqueLight,
-        TransparentLight
+        TransparentLight,
+        BillieWater
     }
 
     internal class GeometryFactory
@@ -68,7 +69,7 @@ namespace Chroma.EnvironmentEnhancement
 
         internal static bool IsLightType(ShaderType shaderType)
         {
-            return shaderType is ShaderType.OpaqueLight or ShaderType.TransparentLight;
+            return shaderType is ShaderType.OpaqueLight or ShaderType.TransparentLight or ShaderType.BillieWater;
         }
 
         internal GameObject Create(CustomData customData)
@@ -77,12 +78,7 @@ namespace Chroma.EnvironmentEnhancement
             bool collision = customData.Get<bool?>(_v2 ? V2_COLLISION : COLLISION) ?? false;
 
             object materialData = customData.GetRequired<object>(_v2 ? V2_MATERIAL : MATERIAL);
-            MaterialsManager.MaterialInfo materialInfo = materialData switch
-            {
-                string name => _materialsManager.MaterialInfos[name],
-                CustomData data => _materialsManager.CreateMaterialInfo(data),
-                _ => throw new InvalidOperationException($"Could not read [{MATERIAL}].")
-            };
+            MaterialsManager.MaterialInfo materialInfo = _materialsManager.GetMaterial(materialData);
             ShaderType shaderType = materialInfo.ShaderType;
 
             PrimitiveType primitiveType = geometryType switch

--- a/Chroma/EnvironmentEnhancement/MaterialsManager.cs
+++ b/Chroma/EnvironmentEnhancement/MaterialsManager.cs
@@ -182,7 +182,7 @@ namespace Chroma.EnvironmentEnhancement
                 material.shaderKeywords = shaderKeywords;
             }
 
-            MaterialInfo materialInfo = new(shaderType, material, track, originalMaterial);
+            MaterialInfo materialInfo = new(shaderType, material, track);
             if (track != null)
             {
                 _materialColorAnimator.Value.Add(materialInfo);
@@ -240,19 +240,16 @@ namespace Chroma.EnvironmentEnhancement
             internal MaterialInfo(
                 ShaderType shaderType,
                 Material material,
-                List<Track>? track, Material originalMaterial)
+                List<Track>? track)
             {
                 ShaderType = shaderType;
                 Material = material;
                 Track = track;
-                OriginalMaterial = originalMaterial;
             }
 
             internal ShaderType ShaderType { get; }
 
             internal Material Material { get; }
-
-            internal Material OriginalMaterial { get; }
 
             internal List<Track>? Track { get; }
         }

--- a/Chroma/EnvironmentEnhancement/MaterialsManager.cs
+++ b/Chroma/EnvironmentEnhancement/MaterialsManager.cs
@@ -171,7 +171,7 @@ namespace Chroma.EnvironmentEnhancement
                         "HEIGHT_FOG", "REFLECTION_PROBE_BOX_PROJECTION", "SPECULAR", "_EMISSION",
                         "_ENABLE_FOG_TINT", "_RIMLIGHT_NONE"
                     },
-                    ShaderType.BillieWater => new[]
+                    ShaderType.BaseWater => new[]
                     {
                         "FOG", "HEIGHT_FOG", "INVERT_RIMLIGHT", "MASK_RED_IS_ALPHA", "NOISE_DITHERING",
                         "NORMAL_MAP", "REFLECTION_PROBE", "REFLECTION_PROBE_BOX_PROJECTION", "_DECALBLEND_ALPHABLEND",

--- a/Chroma/EnvironmentEnhancement/MaterialsManager.cs
+++ b/Chroma/EnvironmentEnhancement/MaterialsManager.cs
@@ -104,18 +104,6 @@ namespace Chroma.EnvironmentEnhancement
                 }
 
                 loadedScenes.Add(sceneInfoSceneName);
-                //
-                // EnvironmentSceneSetupData environmentSceneSetupData = new(environmentInfoSO, null, false);
-                // SingleFixedSceneScenesTransitionSetupDataSO? setupData = ScriptableObject.CreateInstance<SingleFixedSceneScenesTransitionSetupDataSO>();
-                // setupData.Init(environmentSceneSetupData);
-                // gameScenesManager.PushScenes(setupData);
-                //
-                //
-                //
-                // return () =>
-                // {
-                //     gameScenesManager.PopScenes();
-                // }
             }
 
             LoadEnvironmentScene("BTS");

--- a/Chroma/EnvironmentEnhancement/MaterialsManager.cs
+++ b/Chroma/EnvironmentEnhancement/MaterialsManager.cs
@@ -2,13 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using CustomJSONData.CustomBeatmap;
-using Heck;
 using Heck.Animation;
 using IPA.Utilities;
 using JetBrains.Annotations;
 using UnityEngine;
 using Zenject;
 using static Chroma.ChromaController;
+using Logger = IPA.Logging.Logger;
 using Object = UnityEngine.Object;
 
 namespace Chroma.EnvironmentEnhancement
@@ -81,16 +81,19 @@ namespace Chroma.EnvironmentEnhancement
                 if (material != null)
                 {
                     EnvironmentMaterialInfos[key] = material;
+                    Log.Logger.Log($"Found {name} material in current environment", Logger.Level.Info);
                 }
                 else
                 {
-                    Log.Logger.Log($"Could not find {name} material in current environment");
+                    Log.Logger.Log($"Could not find {name} material in current environment", Logger.Level.Info);
                 }
             }
 
 
             GetEnvironmentMaterial("BTSPillar", "BTSDarkEnvironmentWithHeightFog");
             GetEnvironmentMaterial("BillieWater", "WaterfallFalling");
+            GetEnvironmentMaterial("InterscopeConcrete", "Concrete2");
+            GetEnvironmentMaterial("InterscopeCar", "Car");
         }
 
         internal MaterialInfo GetMaterial(object o)
@@ -120,7 +123,7 @@ namespace Chroma.EnvironmentEnhancement
             {
                 if (!EnvironmentMaterialInfos.TryGetValue(environmentMaterial, out originalMaterial))
                 {
-                    Log.Logger.Log($"Could not find {environmentMaterial} in environment materials");
+                    Log.Logger.Log($"Could not find {environmentMaterial} in environment materials, falling back to {shaderType}", Logger.Level.Warning);
                 }
             }
 

--- a/Chroma/EnvironmentEnhancement/MaterialsManager.cs
+++ b/Chroma/EnvironmentEnhancement/MaterialsManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using CustomJSONData.CustomBeatmap;
+using Heck;
 using Heck.Animation;
 using IPA.Utilities;
 using JetBrains.Annotations;
@@ -17,12 +18,17 @@ namespace Chroma.EnvironmentEnhancement
         private static readonly Material _standardMaterial = InstantiateSharedMaterial(ShaderType.Standard);
         private static readonly Material _opaqueLightMaterial = InstantiateSharedMaterial(ShaderType.OpaqueLight);
         private static readonly Material _transparentLightMaterial = InstantiateSharedMaterial(ShaderType.TransparentLight);
+        private static readonly Material _billieWaterMaterial = InstantiateSharedMaterial(ShaderType.BillieWater);
 
         private readonly HashSet<Material> _createdMaterials = new();
 
         private readonly Dictionary<string, Track> _beatmapTracks;
         private readonly LazyInject<MaterialColorAnimator> _materialColorAnimator;
         private readonly bool _v2;
+
+        private Dictionary<string, MaterialInfo> MaterialInfos { get; } = new();
+
+        private Dictionary<string, Material> EnvironmentMaterialInfos { get; } = new();
 
         [UsedImplicitly]
         private MaterialsManager(
@@ -34,6 +40,8 @@ namespace Chroma.EnvironmentEnhancement
             _v2 = beatmapData.version2_6_0AndEarlier;
             _beatmapTracks = beatmapTracks;
             _materialColorAnimator = materialColorAnimator;
+
+            SetupEnvironmentMaterials();
 
             CustomData? materialsData = beatmapData.customData.Get<CustomData>(_v2 ? V2_MATERIALS : MATERIALS);
             if (materialsData == null)
@@ -52,8 +60,6 @@ namespace Chroma.EnvironmentEnhancement
             }
         }
 
-        internal Dictionary<string, MaterialInfo> MaterialInfos { get; } = new();
-
         public void Dispose()
         {
             foreach (Material createdMaterial in _createdMaterials)
@@ -62,19 +68,73 @@ namespace Chroma.EnvironmentEnhancement
             }
         }
 
+        private void SetupEnvironmentMaterials()
+        {
+            // TODO: Load environemnt scenes so we can get all possible materials. A necessary evil :)
+            // This is the only way I could think of for getting materials by name
+            Material[] environmentMaterials = Resources.FindObjectsOfTypeAll<Material>();
+
+            void GetEnvironmentMaterial(string key, string name)
+            {
+                // I use contains here because I can't be bothered to care about identical names
+                Material? material = environmentMaterials.FirstOrDefault(e => e.name.Contains(name));
+                if (material != null)
+                {
+                    EnvironmentMaterialInfos[key] = material;
+                }
+                else
+                {
+                    Log.Logger.Log($"Could not find {name} material in current environment");
+                }
+            }
+
+
+            GetEnvironmentMaterial("BTSPillar", "BTSDarkEnvironmentWithHeightFog");
+            GetEnvironmentMaterial("BillieWater", "WaterfallFalling");
+        }
+
+        internal MaterialInfo GetMaterial(object o)
+        {
+            return o switch
+            {
+                    string name => MaterialInfos.TryGetValue(name, out MaterialInfo info) ? info : throw new InvalidOperationException($"Could not find {name} material"),
+                    CustomData data => CreateMaterialInfo(data),
+                    _ => throw new InvalidOperationException($"Could not read [{MATERIAL}].")
+            };
+        }
+
         internal MaterialInfo CreateMaterialInfo(CustomData customData)
         {
             Color color = CustomDataManager.GetColorFromData(customData, _v2) ?? new Color(0, 0, 0, 0);
             ShaderType shaderType = customData.GetStringToEnumRequired<ShaderType>(_v2 ? V2_SHADER_PRESET : SHADER_PRESET);
             string[]? shaderKeywords = customData.Get<List<object>?>(_v2 ? V2_SHADER_KEYWORDS : SHADER_KEYWORDS)?.Cast<string>().ToArray();
             List<Track>? track = customData.GetNullableTrackArray(_beatmapTracks, _v2)?.ToList();
+            string? environmentMaterial = customData.Get<string?>(_v2 ? V2_ENVIRONMENT_MATERIAL : ENVIRONMENT_MATERIAL);
 
-            Material originalMaterial = shaderType switch
+            // if the environment material does not exist
+            // it fallbacks to shaderType
+            // this is because I have no idea if all materials will be available
+            // on all environments
+            Material originalMaterial = null!;
+            if (environmentMaterial != null)
             {
-                ShaderType.OpaqueLight => _opaqueLightMaterial,
-                ShaderType.TransparentLight => _transparentLightMaterial,
-                _ => _standardMaterial
-            };
+                if (!EnvironmentMaterialInfos.TryGetValue(environmentMaterial, out originalMaterial))
+                {
+                    Log.Logger.Log($"Could not find {environmentMaterial} in environment materials");
+                }
+            }
+
+            if (originalMaterial == null)
+            {
+                originalMaterial = shaderType switch
+                {
+                    ShaderType.OpaqueLight => _opaqueLightMaterial,
+                    ShaderType.TransparentLight => _transparentLightMaterial,
+                    ShaderType.BillieWater => _billieWaterMaterial,
+                    _ => _standardMaterial
+                };
+            }
+
             Material material = Object.Instantiate(originalMaterial);
             _createdMaterials.Add(material);
             material.color = color;
@@ -98,6 +158,7 @@ namespace Chroma.EnvironmentEnhancement
             {
                 ShaderType.OpaqueLight => "Custom/OpaqueNeonLight",
                 ShaderType.TransparentLight => "Custom/TransparentNeonLight",
+                ShaderType.BillieWater => "Custom/WaterLit",
                 _ => "Custom/SimpleLit"
             }))
             {
@@ -113,6 +174,14 @@ namespace Chroma.EnvironmentEnhancement
                         "DIFFUSE", "ENABLE_DIFFUSE", "ENABLE_FOG", "ENABLE_HEIGHT_FOG", "ENABLE_SPECULAR", "FOG",
                         "HEIGHT_FOG", "REFLECTION_PROBE_BOX_PROJECTION", "SPECULAR", "_EMISSION",
                         "_ENABLE_FOG_TINT", "_RIMLIGHT_NONE"
+                    },
+                    ShaderType.BillieWater => new[]
+                    {
+                        "FOG", "HEIGHT_FOG", "INVERT_RIMLIGHT", "MASK_RED_IS_ALPHA", "NOISE_DITHERING",
+                        "NORMAL_MAP", "REFLECTION_PROBE", "REFLECTION_PROBE_BOX_PROJECTION", "_DECALBLEND_ALPHABLEND",
+                        "_DISSOLVEAXIS_LOCALX", "_EMISSIONCOLORTYPE_FLAT", "_EMISSIONTEXTURE_NONE",
+                        "_RIMLIGHT_NONE", "_ROTATE_UV_NONE", "_VERTEXMODE_NONE", "_WHITEBOOSTTYPE_NONE",
+                        "_ZWRITE_ON"
                     },
                     ShaderType.OpaqueLight => new[]
                     {

--- a/Chroma/EnvironmentEnhancement/MaterialsManager.cs
+++ b/Chroma/EnvironmentEnhancement/MaterialsManager.cs
@@ -94,6 +94,7 @@ namespace Chroma.EnvironmentEnhancement
             GetEnvironmentMaterial("BillieWater", "WaterfallFalling");
             GetEnvironmentMaterial("InterscopeConcrete", "Concrete2");
             GetEnvironmentMaterial("InterscopeCar", "Car");
+            GetEnvironmentMaterial("Obstacle", "ObstacleCoreHD");
         }
 
         internal MaterialInfo GetMaterial(object o)

--- a/Chroma/HeckImplementation/ModuleCallbacks.cs
+++ b/Chroma/HeckImplementation/ModuleCallbacks.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Chroma.EnvironmentEnhancement;
 using Chroma.Lighting;
 using Chroma.Settings;
 using CustomJSONData;
@@ -37,7 +38,9 @@ namespace Chroma
                 Log.Logger.Log("Please do not use Legacy Chroma Lights for new maps as it is deprecated and its functionality in future versions of Chroma cannot be guaranteed", Logger.Level.Warning);
             }
 
-            LightIDTableManager.SetEnvironment(difficultyBeatmap.GetEnvironmentInfo().serializedName);
+            EnvironmentInfoSO currentEnvironmentSO = difficultyBeatmap.GetEnvironmentInfo();
+            MaterialsManager.CurrentEnvironmentSO = currentEnvironmentSO;
+            LightIDTableManager.SetEnvironment(currentEnvironmentSO.serializedName);
 
             return (chromaRequirement || legacyOverride) && !ChromaConfig.Instance.ChromaEventsDisabled;
         }


### PR DESCRIPTION
Adds the ability to use materials loaded in the scene
Example usage: 
```jsonc
"_material": {
  "_shader": "BTSPillar" // takes precedences over "_shader"
}
```
Possible options as of writing this are: 
- `BillieWater` - Uses the waterfall material (not the mirror distorted water)
- `BTSPillar` - Uses the BTS Pillar Cube material
- BaseWater
- BillieWater
- WaterfallMirror
- Obstacle (obstacle material)
- InterscopeConcrete
- InterscopeCar


This PR does not undermine the rest of the geometry functionality, as it allows for usage with different shapes and Unity scale. You can also color (animate) and change the shader keywords as expected.