### PR TITLE
HSV Lerp

### DIFF
--- a/Heck/Animation/PointDefinition.cs
+++ b/Heck/Animation/PointDefinition.cs
@@ -291,12 +291,14 @@ namespace Heck.Animation
 
             normalTime = Easings.Interpolate(normalTime, pointDataR.Easing);
 
-            // Convert to HSV if the next point is HSV lerp
-            // So the lerp is proper
-            if (pointDataR.HSV && !pointDataL.HSV)
+            pointL = pointDataR.HSV switch
             {
-                pointL = pointL.ToHSV();
-            }
+                // Convert to HSV if the next point is HSV lerp
+                // So the lerp is proper
+                true when !pointDataL.HSV => pointL.ToHSV(),
+                false when pointDataL.HSV => pointL.ToRGB(),
+                _ => pointL
+            };
 
             Vector4 result = Vector4.LerpUnclamped(pointL, pointR, normalTime);
 

--- a/Heck/Animation/PointDefinition.cs
+++ b/Heck/Animation/PointDefinition.cs
@@ -408,7 +408,7 @@ namespace Heck.Animation
 
             public Vector5 ToHSV()
             {
-                Color c = new(x, y, z, v);
+                Color c = new(x, y, z, w);
                 Color.RGBToHSV(c, out float h, out float s, out float b);
                 return new Vector5(h, s, b, w, v);
             }

--- a/Heck/Animation/PointDefinition.cs
+++ b/Heck/Animation/PointDefinition.cs
@@ -300,11 +300,13 @@ namespace Heck.Animation
 
             Vector4 result = Vector4.LerpUnclamped(pointL, pointR, normalTime);
 
+            // RGB lerp
             if (!pointDataR.HSV)
             {
                 return result;
             }
 
+            // HSV lerp
             float alpha = result.w;
             result = Color.HSVToRGB(result.x, result.y, result.y, true);
             result.w = alpha;

--- a/Heck/Animation/PointDefinition.cs
+++ b/Heck/Animation/PointDefinition.cs
@@ -85,7 +85,7 @@ namespace Heck.Animation
                     default:
                     {
                         Vector5 vector = new(Convert.ToSingle(copiedList[0]), Convert.ToSingle(copiedList[1]), Convert.ToSingle(copiedList[2]), Convert.ToSingle(copiedList[3]), Convert.ToSingle(copiedList[4]));
-                        pointData.Add(new PointData(hsv ? vector.ToHSV() : vector, hsv, easing));
+                        pointData.Add(new PointData(vector, hsv, easing));
                         break;
                     }
                 }
@@ -291,24 +291,23 @@ namespace Heck.Animation
 
             normalTime = Easings.Interpolate(normalTime, pointDataR.Easing);
 
-            pointL = pointDataR.HSV switch
+            // If next point is HSV, convert both values to HSV
+            bool hsv = pointDataR.HSV;
+            if (hsv)
             {
-                // Convert to HSV if the next point is HSV lerp
-                // So the lerp is proper
-                true when !pointDataL.HSV => pointL.ToHSV(),
-                false when pointDataL.HSV => pointL.ToRGB(),
-                _ => pointL
-            };
+                pointL = pointL.ToHSV();
+                pointR = pointR.ToHSV();
+            }
 
             Vector4 result = Vector4.LerpUnclamped(pointL, pointR, normalTime);
 
             // RGB lerp
-            if (!pointDataR.HSV)
+            if (!hsv)
             {
                 return result;
             }
 
-            // HSV lerp
+            // HSV lerp, convert to RGB
             float alpha = result.w;
             result = Color.HSVToRGB(result.x, result.y, result.y, true);
             result.w = alpha;
@@ -405,13 +404,6 @@ namespace Heck.Animation
             public static implicit operator Quaternion(Vector5 vector)
             {
                 return new Quaternion(vector.x, vector.y, vector.z, vector.w);
-            }
-
-            public Vector5 ToRGB()
-            {
-                Vector4 result = Color.HSVToRGB(x, y, z, true);
-                result.w = w;
-                return new Vector5(result.x, result.y, result.z, result.w, v);
             }
 
             public Vector5 ToHSV()

--- a/Heck/Animation/PointDefinition.cs
+++ b/Heck/Animation/PointDefinition.cs
@@ -289,13 +289,20 @@ namespace Heck.Animation
 
             normalTime = Easings.Interpolate(normalTime, _points[r].Easing);
 
+            // TODO: Figure out a much simpler way to do this
+            // I'm 99% sure I'm overcomplicating this when it's likely a simple solution
             if (!_points[r].HSV)
             {
-                return Vector4.LerpUnclamped(pointL, pointR, normalTime);
+                // Convert previous point from HSV to RGB if it's HSV
+                // RGB Lerp
+                return Vector4.LerpUnclamped(_points[l].HSV ? pointL.ToRGB() : pointL, pointR, normalTime);
             }
 
-            // HSV convert
-            Vector4 preResult = Vector4.LerpUnclamped(pointL, pointR, normalTime);
+            // Convert previous point to RGB if needed
+            // HSV lerp
+            Vector4 preResult = Vector4.LerpUnclamped(_points[l].HSV ? pointL : pointL.ToHSV(), pointR, normalTime);
+
+            // HSV convert to RGB
             Vector4 result = Color.HSVToRGB(preResult.x, preResult.y, preResult.z, true);
             result.w = preResult.w;
             return result;
@@ -390,6 +397,20 @@ namespace Heck.Animation
             public static implicit operator Quaternion(Vector5 vector)
             {
                 return new Quaternion(vector.x, vector.y, vector.z, vector.w);
+            }
+
+            public Vector5 ToRGB()
+            {
+                Vector4 result = Color.HSVToRGB(x, y, z, true);
+                result.w = w;
+                return new Vector5(result.x, result.y, result.z, result.w, v);
+            }
+
+            public Vector5 ToHSV()
+            {
+                Color c = new(x, y, z, v);
+                Color.RGBToHSV(c, out float h, out float s, out float b);
+                return new Vector5(h, s, b, w, v);
             }
         }
 

--- a/Heck/Animation/PointDefinition.cs
+++ b/Heck/Animation/PointDefinition.cs
@@ -64,7 +64,7 @@ namespace Heck.Animation
                     }
                 }
 
-                bool hsv = flags.Any(n => n == "hsv");
+                bool hsv = flags.Any(n => n == "hsvLerp");
 
                 switch (copiedList.Count)
                 {


### PR DESCRIPTION
This PR allows the ability to lerp colors using HSV.
~Currently, it assumes the values in the pointData are in HSV format.~
~Simply put, it lerps the values and then converts them to RGB.~

The values are in RGB format. When the next point (pointR) is marked `hsv`, the values will be lerped using HSV values and converted back to RGB internally

Usage:
```json
"color": [
[1.0, 0.0, 0.0, 1.0, 0.0], 
[0.0, 0.0, 1.0, 1.0, 1.0, "hsv"]
]
```