### PR TITLE
Add Custom Events (Triggers)

### DIFF
--- a/Heck/Animation/Events/CoroutineEventManager.cs
+++ b/Heck/Animation/Events/CoroutineEventManager.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using CustomJSONData.CustomBeatmap;
 using JetBrains.Annotations;
 using UnityEngine;
@@ -39,6 +41,24 @@ namespace Heck.Animation.Events
             if (!_deserializedData.Resolve(customEventData, out HeckCoroutineEventData? heckData))
             {
                 return;
+            }
+
+            IEnumerable<Trigger> triggers = heckData.Triggers;
+            if (triggers != null)
+            {
+                bool triggered = false;
+                foreach (Trigger trigger in triggers)
+                {
+                    if (trigger.isTriggered)
+                    {
+                        triggered = true;
+                        break;
+                    }
+                }
+                if (!triggered)
+                {
+                    return;
+                }
             }
 
             float duration = 60f * heckData.Duration / _bpmController.currentBpm; // Convert to real time;

--- a/Heck/Animation/Events/EventController.cs
+++ b/Heck/Animation/Events/EventController.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using CustomJSONData.CustomBeatmap;
 using JetBrains.Annotations;
+using UnityEngine;
 using Zenject;
+using static AlphabetScrollInfo;
 using static Heck.HeckController;
 
 namespace Heck.Animation.Events
@@ -11,20 +15,58 @@ namespace Heck.Animation.Events
         private readonly BeatmapCallbacksController _callbacksController;
         private readonly LazyInject<CoroutineEventManager> _coroutineEventManager;
         private readonly BeatmapDataCallbackWrapper _callbackWrapper;
+        private readonly BeatmapObjectManager _beatmapObjectManager;
 
         [UsedImplicitly]
         private EventController(
             BeatmapCallbacksController callbacksController,
-            LazyInject<CoroutineEventManager> coroutineEventManager)
+            LazyInject<CoroutineEventManager> coroutineEventManager,
+            BeatmapObjectManager beatmapObjectManager)
         {
             _callbacksController = callbacksController;
             _coroutineEventManager = coroutineEventManager;
             _callbackWrapper = callbacksController.AddBeatmapCallback<CustomEventData>(HandleCallback);
+            _beatmapObjectManager = beatmapObjectManager;
+            _beatmapObjectManager.noteWasCutEvent += BeatmapObjectManager_noteWasCutEvent;
+            _beatmapObjectManager.noteWasMissedEvent += BeatmapObjectManager_noteWasMissedEvent;
+        }
+
+        private void BeatmapObjectManager_noteWasMissedEvent(NoteController noteController)
+        {
+            CustomNoteData noteData = (CustomNoteData)noteController._noteData;
+            IEnumerable<Trigger> triggers = Trigger.GetTriggers(noteData.customData, "triggerOnMiss");
+            if (triggers == null)
+            {
+                return;
+            }
+
+            foreach (Trigger trigger in triggers)
+            {
+                trigger.isTriggered = true;
+            }
+        }
+
+        private void BeatmapObjectManager_noteWasCutEvent(NoteController noteController, in NoteCutInfo _)
+        {
+            CustomNoteData noteData = (CustomNoteData)noteController._noteData;
+            IEnumerable<Trigger> triggers = Trigger.GetTriggers(noteData.customData, "triggerOnCut");
+            if (triggers == null)
+            {
+                return;
+            }
+
+            foreach (Trigger trigger in triggers)
+            {
+                trigger.isTriggered = true;
+            }
         }
 
         public void Dispose()
         {
             _callbacksController.RemoveBeatmapCallback(_callbackWrapper);
+            _beatmapObjectManager.noteWasCutEvent -= BeatmapObjectManager_noteWasCutEvent;
+            _beatmapObjectManager.noteWasMissedEvent -= BeatmapObjectManager_noteWasMissedEvent;
+            Trigger.triggers.Clear();
         }
 
         private void HandleCallback(CustomEventData customEventData)

--- a/Heck/Animation/Trigger.cs
+++ b/Heck/Animation/Trigger.cs
@@ -1,0 +1,58 @@
+﻿using CustomJSONData.CustomBeatmap;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Heck.Animation
+{
+    internal class Trigger
+    {
+        public static Dictionary<string, Trigger> triggers = new Dictionary<string, Trigger>();
+
+        public Trigger(string _name) {
+            name = _name;
+        }
+
+        public bool isTriggered = false;
+
+        public string name;
+
+        public static IEnumerable<Trigger> GetTriggers(CustomData data, string field)
+        {
+            object? triggerNameRaw = data.Get<object>(field);
+            if (triggerNameRaw == null)
+            {
+                return null;
+            }
+
+            IEnumerable<string> triggerNames;
+            if (triggerNameRaw is List<object> listTrack)
+            {
+                triggerNames = listTrack.Cast<string>();
+            }
+            else
+            {
+                triggerNames = new[] { (string)triggerNameRaw };
+            }
+
+            HashSet<Trigger> result = new();
+            foreach (string triggerName in triggerNames)
+            {
+                if (triggers.ContainsKey(triggerName))
+                {
+                    result.Add(triggers[triggerName]);
+                }
+                else
+                {
+                    Trigger trigger = new Trigger(triggerName);
+                    result.Add(trigger);
+                    triggers.Add(triggerName, trigger);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/Heck/HeckController.cs
+++ b/Heck/HeckController.cs
@@ -20,6 +20,7 @@
         public const string V2_LOCAL_POSITION = "_localPosition";
         public const string V2_SCALE = "_scale";
 
+        public const string TRIGGER = "trigger";
         public const string REPEAT = "repeat";
         public const string DURATION = "duration";
         public const string EASING = "easing";

--- a/Heck/HeckImplementation/CustomDataTypes.cs
+++ b/Heck/HeckImplementation/CustomDataTypes.cs
@@ -21,7 +21,7 @@ namespace Heck
 
             IEnumerable<Track> tracks = data.GetTrackArray(beatmapTracks, v2);
 
-            string[] excludedStrings = { V2_TRACK, V2_DURATION, V2_EASING, TRACK, DURATION, EASING, REPEAT };
+            string[] excludedStrings = { V2_TRACK, V2_DURATION, V2_EASING, TRACK, DURATION, EASING, REPEAT, TRIGGER };
             IEnumerable<string> propertyKeys = data.Keys.Where(n => excludedStrings.All(m => m != n)).ToList();
             List<CoroutineInfo> coroutineInfos = new();
             foreach (Track track in tracks)
@@ -97,6 +97,7 @@ namespace Heck
             if (!v2)
             {
                 Repeat = data.Get<int?>(REPEAT) ?? 0;
+                Triggers = Trigger.GetTriggers(data, TRIGGER);
             }
         }
 
@@ -105,6 +106,8 @@ namespace Heck
         internal Functions Easing { get; }
 
         internal int Repeat { get; }
+
+        internal IEnumerable<Trigger> Triggers { get; }
 
         internal List<CoroutineInfo> CoroutineInfos { get; }
 


### PR DESCRIPTION
This code should allow you to add triggers to enable AnimationTracks. It add the next properties to notes
triggerOnMiss and triggerOnCut, can be a simple string or an array of strings (allowing to trigger multiple triggers).
AnimationTrack has a new field called "trigger" it also can be a string or an array allowing for different triggers to trigger it.
Notes:
- If the beat of the AnimationTrack occurs before the event, it won't be triggered.
- triggerOnMiss has some delay and is not at the same beat of the note, so you have to make sure the AnimationTrack is a bit later, I have tested 150ms to work
- More events should be added but I am not sure how (hit wall event? dodge wall event?, hit bomb event?, dodgeBomb event?)

Example of Custom Data:
`"colorNotes": [
		{
			"b": 25,
			"x": 2,
			"c": 1,
			"d": 1,
			"customData": {
				"triggerOnMiss": "tm0",
				"triggerOnCut": "tc0"
			}
		}
]`

`"customEvents": [
			{
				"b": 25.15,
				"t": "AnimateTrack",
				"d": {
					"track": "ttest",
					"duration": 0.5,
					"trigger": "tc0",
					"position": [
						[
							-1.46,
							0.4,
							8.913,
							0
						],
						[
							-1.46,
							2,
							8.913,
							0.5,
							"easeOutCirc"
						],
						[
							-1.46,
							0.4,
							8.913,
							1,
							"easeInCirc"
						]
					]
				}
			},
			{
				"b": 25.15,
				"t": "AnimateTrack",
				"d": {
					"track": "ttest",
					"duration": 0.5,
					"trigger": "tm0",
					"position": [
						[
							-1.46,
							0.4,
							8.913,
							0
						],
						[
							-2.46,
							0.4,
							8.913,
							0.33,
							"easeOutBack"
						],
						[
							-0.45999999999999999,
							0.4,
							8.913,
							0.66,
							"easeInOutBack"
						],
						[
							-1.46,
							0.4,
							8.913,
							1,
							"easeInOutBack"
						]
					]
				}
			}
]`