### PR TITLE
[WIP] Fix half jump for many v2 modcharts

### DIFF
--- a/NoodleExtensions/HeckImplementation/CustomDataTypes.cs
+++ b/NoodleExtensions/HeckImplementation/CustomDataTypes.cs
@@ -267,6 +267,8 @@ namespace NoodleExtensions
 
                 NJS = customData.Get<float?>(v2 ? V2_NOTE_JUMP_SPEED : NOTE_JUMP_SPEED);
                 SpawnOffset = customData.Get<float?>(v2 ? V2_NOTE_SPAWN_OFFSET : NOTE_SPAWN_OFFSET);
+
+                V2 = v2;
             }
             catch (Exception e)
             {
@@ -307,6 +309,8 @@ namespace NoodleExtensions
         internal float? SpawnOffset { get; }
 
         internal float? InternalAheadTime { get; set; }
+
+        internal bool? V2 { get; }
 
         internal float? GetTimeProperty()
         {

--- a/NoodleExtensions/Managers/NoodleObjectsCallbacksManager.cs
+++ b/NoodleExtensions/Managers/NoodleObjectsCallbacksManager.cs
@@ -118,9 +118,10 @@ namespace NoodleExtensions.Managers
                         throw new InvalidOperationException("Failed to get data.");
                     }
 
+                    bool? v2 = noodleData.V2;
                     float? noteJumpMovementSpeed = noodleData.NJS;
                     float? noteJumpStartBeatOffset = noodleData.SpawnOffset;
-                    float aheadTime = _spawnDataManager.GetSpawnAheadTime(noteJumpMovementSpeed, noteJumpStartBeatOffset);
+                    float aheadTime = _spawnDataManager.GetSpawnAheadTime(v2, noteJumpMovementSpeed, noteJumpStartBeatOffset);
                     noodleData.InternalAheadTime = aheadTime;
                     return beatmapObjectData.time - aheadTime;
                 });


### PR DESCRIPTION
# Why?
Since 1.20, Beat Games seemingly decided to change how calculating the half jump duration works, making the minimum half jump duration go from 1 beat down to 0.25 beats. This change broke many old v2 modcharts, which took advantage of this quirk, leaving them in a state that makes them look horribly wrong (e.g. parts missing, showing too fast, etc).

This PR reverts the change Beat Games did to calculating the half jump duration, fixing many v2 modcharts, making them look a lot more proper. I am unsure as to if this code fits the general codestyle of Chroma/NE/Heck, but hopefully this is good enough.

# Examples of broken modcharts with/without fix

"NULCTRL" (without fix): https://github.com/Aeroluna/Heck/assets/87990853/c225d307-7553-4916-b629-25777dfed51e
"NULCTRL" (with fix): https://github.com/Aeroluna/Heck/assets/87990853/12ce8788-eef0-4be7-a7cf-14b275ee37fd

"Try" (without fix): https://github.com/Aeroluna/Heck/assets/87990853/109f2d2e-09b5-4c76-bf1a-56c349440e63
"Try" (with fix): https://github.com/Aeroluna/Heck/assets/87990853/2b7010d7-ee10-463d-917a-4238a0d213fb

There are many more broken modcharts that were like this, that should hopefully be mostly fixed with this PR.