### PR TITLE
Fix materials get darker colors on 1.34.2+

### DIFF
--- a/Chroma/EnvironmentEnhancement/MaterialsManager.cs
+++ b/Chroma/EnvironmentEnhancement/MaterialsManager.cs
@@ -101,6 +101,7 @@ namespace Chroma.EnvironmentEnhancement
             if (color != null)
             {
                 material.color = color.Value;
+                material.SetFloat("_Metallic", 0);
             }
 
             if (shaderKeywords != null)

--- a/Chroma/EnvironmentEnhancement/MaterialsManager.cs
+++ b/Chroma/EnvironmentEnhancement/MaterialsManager.cs
@@ -28,6 +28,8 @@ namespace Chroma.EnvironmentEnhancement
         private readonly LazyInject<MaterialColorAnimator> _materialColorAnimator;
         private readonly bool _v2;
 
+        private static readonly int _metallicPropertyID = Shader.PropertyToID("_Metallic");
+
         [UsedImplicitly]
         private MaterialsManager(
             EnvironmentMaterialsManager environmentMaterialsManager,
@@ -103,7 +105,7 @@ namespace Chroma.EnvironmentEnhancement
                 material.color = color.Value;
                 if (shaderType == ShaderType.Standard)
                 {
-                    material.SetFloat("_Metallic", 0);
+                    material.SetFloat(_metallicPropertyID, 0);
                 }
             }
 

--- a/Chroma/EnvironmentEnhancement/MaterialsManager.cs
+++ b/Chroma/EnvironmentEnhancement/MaterialsManager.cs
@@ -16,6 +16,8 @@ namespace Chroma.EnvironmentEnhancement
 {
     internal class MaterialsManager : IDisposable
     {
+        private static readonly int _metallicPropertyID = Shader.PropertyToID("_Metallic");
+
         private static readonly Material _standardMaterial = InstantiateSharedMaterial(ShaderType.Standard);
         private static readonly Material _opaqueLightMaterial = InstantiateSharedMaterial(ShaderType.OpaqueLight);
         private static readonly Material _transparentLightMaterial = InstantiateSharedMaterial(ShaderType.TransparentLight);
@@ -27,8 +29,6 @@ namespace Chroma.EnvironmentEnhancement
         private readonly Dictionary<string, Track> _beatmapTracks;
         private readonly LazyInject<MaterialColorAnimator> _materialColorAnimator;
         private readonly bool _v2;
-
-        private static readonly int _metallicPropertyID = Shader.PropertyToID("_Metallic");
 
         [UsedImplicitly]
         private MaterialsManager(
@@ -103,10 +103,6 @@ namespace Chroma.EnvironmentEnhancement
             if (color != null)
             {
                 material.color = color.Value;
-                if (shaderType == ShaderType.Standard)
-                {
-                    material.SetFloat(_metallicPropertyID, 0);
-                }
             }
 
             if (shaderKeywords != null)
@@ -125,7 +121,7 @@ namespace Chroma.EnvironmentEnhancement
 
         private static Material InstantiateSharedMaterial(ShaderType shaderType)
         {
-            return new Material(Shader.Find(shaderType switch
+            Material material = new Material(Shader.Find(shaderType switch
             {
                 ShaderType.OpaqueLight => "Custom/OpaqueNeonLight",
                 ShaderType.TransparentLight => "Custom/TransparentNeonLight",
@@ -170,6 +166,12 @@ namespace Chroma.EnvironmentEnhancement
                 },
                 color = new Color(0, 0, 0, 0)
             };
+            if (shaderType == ShaderType.Standard)
+            {
+                material.SetFloat(_metallicPropertyID, 0);
+            }
+
+            return material;
         }
 
         internal readonly struct MaterialInfo

--- a/Chroma/EnvironmentEnhancement/MaterialsManager.cs
+++ b/Chroma/EnvironmentEnhancement/MaterialsManager.cs
@@ -101,7 +101,10 @@ namespace Chroma.EnvironmentEnhancement
             if (color != null)
             {
                 material.color = color.Value;
-                material.SetFloat("_Metallic", 0);
+                if (shaderType == ShaderType.Standard)
+                {
+                    material.SetFloat("_Metallic", 0);
+                }
             }
 
             if (shaderKeywords != null)


### PR DESCRIPTION
This fixes lighting bug on 1.34.2+ by setting metallic property to 0 on materials with Standard shader type