### PR TITLE
Adjustment to Glowing shader to allow for infinite distance.

### DIFF
--- a/Chroma/EnvironmentEnhancement/MaterialColorAnimator.cs
+++ b/Chroma/EnvironmentEnhancement/MaterialColorAnimator.cs
@@ -22,7 +22,7 @@ internal class MaterialColorAnimator : ITickable
             }
 
 #if !PRE_V1_39_1
-            if (materialInfo.ShaderType is ShaderType.Standard or ShaderType.BTSPillar)
+            if (materialInfo.ShaderType is ShaderType.Standard or ShaderType.BTSPillar && materialInfo.Material.shaderKeywords is { Length: 0 })
             {
                 color = color.Value.ColorWithAlpha(0);
             }

--- a/Chroma/EnvironmentEnhancement/MaterialsManager.cs
+++ b/Chroma/EnvironmentEnhancement/MaterialsManager.cs
@@ -18,6 +18,7 @@ namespace Chroma.EnvironmentEnhancement;
 internal class MaterialsManager : IDisposable
 {
     private static readonly int _metallicPropertyID = Shader.PropertyToID("_Metallic");
+    private static readonly int _fogStartOffsetPropertyID = Shader.PropertyToID("_FogStartOffset");
 
 #if !PRE_V1_37_1
     private static readonly Shader[] _allShaders = Resources.FindObjectsOfTypeAll<Shader>();
@@ -237,6 +238,12 @@ internal class MaterialsManager : IDisposable
         if (shaderType == ShaderType.Standard)
         {
             material.SetFloat(_metallicPropertyID, 0);
+        }
+
+        // Small fix to allow for infinite distance so it doesn't darken
+        if (shaderType == ShaderType.Glowing)
+        {
+            material.SetFloat(_fogStartOffsetPropertyID, float.PositiveInfinity);
         }
 
         return material;


### PR DESCRIPTION
After this fix was implemented, I missed that it darkens with distance. This PR will allow it to be full bright from any distance, similar to the old behavior with empty shaderKeywords. This will also allow it to be infinite distance when using the Glowing shader directly, if one chooses to.

Additionally I added a small adjustment to MaterialColorAnimator so it also checks for empty shaderKeywords so it doesn't set alpha to *all* animated standard shaders.

With this change, this workaround is about fully replicated:
![image](https://github.com/user-attachments/assets/d879b401-7f1b-45ac-be7c-0dee2730d4e5)

Edit: The Byte Order Mark (BOM) got removed in the PR and unsure if it was important so I fixed and force pushed that so that diff doesn't occur.