### PR TITLE
GLS CustomJSONData RGB Chroma support

### DIFF
--- a/Chroma/HarmonyPatches/Events/GlsColorChromafier.cs
+++ b/Chroma/HarmonyPatches/Events/GlsColorChromafier.cs
@@ -13,12 +13,6 @@ namespace Chroma.HarmonyPatches.Events;
 /// <summary>
 /// Applies Chroma custom colors to GLS (LightColorGroupEffect) events.
 ///
-/// V3 maps: CustomJSONData injects <see cref="ICustomData"/> into <c>CustomLightColorBeatmapEventData</c>
-/// via its <c>LightColorBaseDataConvertV3</c> transpiler. Colors are read directly from the event's
-/// <c>customData["color"]</c> at playback time — no file I/O or lookup table required.
-///
-/// V4 maps: not yet supported. Will be handled by V4→V3 deserialization when implemented.
-///
 /// Patch strategy:
 ///   POSTFIX HandleColorChangeBeatmapEvent — after SetData has run, patch _fromColor/_toColor directly.
 ///     SetColor(t) does Color.LerpUnclamped(_fromColor, _toColor, t) every frame, so these two fields

--- a/Chroma/HarmonyPatches/Events/GlsColorChromafier.cs
+++ b/Chroma/HarmonyPatches/Events/GlsColorChromafier.cs
@@ -43,6 +43,8 @@ internal class GlsColorChromafier : IAffinity, IInitializable
     private static readonly MethodInfo SetColorMethod =
         typeof(LightColorGroupEffect).GetMethod("SetColor", BindingFlags.Instance | BindingFlags.NonPublic);
 
+    private static readonly object[] NO_TWEEN_INDICATOR = [0f];
+
     /// <inheritdoc/>
     public void Initialize()
     {
@@ -84,7 +86,7 @@ internal class GlsColorChromafier : IAffinity, IInitializable
             {
                 // Without this we would deviate from the out of the box behavior and change to the next color immediately instead of waiting for its node.
                 // This is because the default implementation sets the color to 0f when there is no tween. It looks dumb AF, though.
-                SetColorMethod.Invoke(__instance, new object[] { 0f });
+                SetColorMethod.Invoke(__instance, NO_TWEEN_INDICATOR);
                 return;
             }
         }

--- a/Chroma/HarmonyPatches/Events/GlsColorChromafier.cs
+++ b/Chroma/HarmonyPatches/Events/GlsColorChromafier.cs
@@ -28,19 +28,19 @@ namespace Chroma.HarmonyPatches.Events;
 /// </summary>
 internal class GlsColorChromafier : IAffinity, IInitializable
 {
-    private static readonly FieldInfo? FromColorField =
+    private static readonly FieldInfo FromColorField =
         typeof(LightColorGroupEffect).GetField("_fromColor", BindingFlags.Instance | BindingFlags.NonPublic);
 
-    private static readonly FieldInfo? ToColorField =
+    private static readonly FieldInfo ToColorField =
         typeof(LightColorGroupEffect).GetField("_toColor", BindingFlags.Instance | BindingFlags.NonPublic);
 
-    private static readonly FieldInfo? AltFromColorField =
+    private static readonly FieldInfo AltFromColorField =
         typeof(LightColorGroupEffect).GetField("_alternativeFromColor", BindingFlags.Instance | BindingFlags.NonPublic);
 
-    private static readonly FieldInfo? AltToColorField =
+    private static readonly FieldInfo AltToColorField =
         typeof(LightColorGroupEffect).GetField("_alternativeToColor", BindingFlags.Instance | BindingFlags.NonPublic);
 
-    private static readonly MethodInfo? SetColorMethod =
+    private static readonly MethodInfo SetColorMethod =
         typeof(LightColorGroupEffect).GetMethod("SetColor", BindingFlags.Instance | BindingFlags.NonPublic);
 
     /// <inheritdoc/>
@@ -48,13 +48,8 @@ internal class GlsColorChromafier : IAffinity, IInitializable
     {
     }
 
-    private static void ApplyColorWithAlpha(FieldInfo? field, LightColorGroupEffect instance, Color customColor)
+    private static void ApplyColorWithAlpha(FieldInfo field, LightColorGroupEffect instance, Color customColor)
     {
-        if (field == null)
-        {
-            return;
-        }
-
         Color existing = (Color)field.GetValue(instance);
         field.SetValue(instance, customColor.ColorWithAlpha(existing.a));
     }
@@ -89,7 +84,7 @@ internal class GlsColorChromafier : IAffinity, IInitializable
             {
                 // Without this we would deviate from the out of the box behavior and change to the next color immediately instead of waiting for its node.
                 // This is because the default implementation sets the color to 0f when there is no tween. It looks dumb AF, though.
-                SetColorMethod?.Invoke(__instance, new object[] { 0f });
+                SetColorMethod.Invoke(__instance, new object[] { 0f });
                 return;
             }
         }

--- a/Chroma/HarmonyPatches/Events/GlsColorChromafier.cs
+++ b/Chroma/HarmonyPatches/Events/GlsColorChromafier.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using CustomJSONData.CustomBeatmap;
+using JetBrains.Annotations;
+using SiraUtil.Affinity;
+using SiraUtil.Logging;
+using UnityEngine;
+using Zenject;
+
+namespace Chroma.HarmonyPatches.Events;
+
+/// <summary>
+/// Applies Chroma custom colors to GLS (LightColorGroupEffect) events.
+///
+/// V3 maps: CustomJSONData injects <see cref="ICustomData"/> into <c>CustomLightColorBeatmapEventData</c>
+/// via its <c>LightColorBaseDataConvertV3</c> transpiler. Colors are read directly from the event's
+/// <c>customData["color"]</c> at playback time — no file I/O or lookup table required.
+///
+/// V4 maps: not yet supported. Will be handled by V4→V3 deserialization when implemented.
+///
+/// Patch strategy:
+///   POSTFIX HandleColorChangeBeatmapEvent — after SetData has run, patch _fromColor/_toColor directly.
+///     SetColor(t) does Color.LerpUnclamped(_fromColor, _toColor, t) every frame, so these two fields
+///     fully control color interpolation. We preserve the game's alpha (brightness) from each field
+///     and replace only the RGB with the custom color. _fromColor gets currentEventData's color;
+///     _toColor gets nextSameTypeEventData's color (if it has a custom color), otherwise left alone.
+/// </summary>
+internal class GlsColorChromafier : IAffinity, IInitializable
+{
+    private static readonly FieldInfo? FromColorField =
+        typeof(LightColorGroupEffect).GetField("_fromColor", BindingFlags.Instance | BindingFlags.NonPublic);
+
+    private static readonly FieldInfo? ToColorField =
+        typeof(LightColorGroupEffect).GetField("_toColor", BindingFlags.Instance | BindingFlags.NonPublic);
+
+    private static readonly FieldInfo? AltFromColorField =
+        typeof(LightColorGroupEffect).GetField("_alternativeFromColor", BindingFlags.Instance | BindingFlags.NonPublic);
+
+    private static readonly FieldInfo? AltToColorField =
+        typeof(LightColorGroupEffect).GetField("_alternativeToColor", BindingFlags.Instance | BindingFlags.NonPublic);
+
+    private static readonly MethodInfo? SetColorMethod =
+        typeof(LightColorGroupEffect).GetMethod("SetColor", BindingFlags.Instance | BindingFlags.NonPublic);
+
+    /// <inheritdoc/>
+    public void Initialize()
+    {
+    }
+
+    private static void ApplyColorWithAlpha(FieldInfo? field, LightColorGroupEffect instance, Color customColor)
+    {
+        if (field == null)
+        {
+            return;
+        }
+
+        Color existing = (Color)field.GetValue(instance);
+        field.SetValue(instance, customColor.ColorWithAlpha(existing.a));
+    }
+
+    private static Color? ResolveCustomColor(LightColorBeatmapEventData eventData)
+    {
+        if (eventData is ICustomData customDataEvent)
+        {
+            return customDataEvent.customData.GetColor("color");
+        }
+
+        return null;
+    }
+
+    [AffinityPostfix]
+    [AffinityPatch(typeof(LightColorGroupEffect), nameof(LightColorGroupEffect.HandleColorChangeBeatmapEvent))]
+    private void PostfixHandleColorChange(
+        LightColorGroupEffect __instance,
+        LightColorBeatmapEventData currentEventData)
+    {
+        Color? fromColor = ResolveCustomColor(currentEventData);
+        var nextEventData = currentEventData.nextSameTypeEventData as LightColorBeatmapEventData;
+        bool hasTween = nextEventData != null && nextEventData.easeType != EaseType.None;
+        Color? toColor = hasTween ? ResolveCustomColor(nextEventData!) : fromColor;
+
+        if (fromColor.HasValue)
+        {
+            ApplyColorWithAlpha(FromColorField, __instance, fromColor.Value);
+            ApplyColorWithAlpha(AltFromColorField, __instance, fromColor.Value);
+
+            if (!hasTween)
+            {
+                // Without this we would deviate from the out of the box behavior and change to the next color immediately instead of waiting for its node.
+                // This is because the default implementation sets the color to 0f when there is no tween. It looks dumb AF, though.
+                SetColorMethod?.Invoke(__instance, new object[] { 0f });
+                return;
+            }
+        }
+
+        if (toColor.HasValue)
+        {
+            ApplyColorWithAlpha(ToColorField, __instance, toColor.Value);
+            ApplyColorWithAlpha(AltToColorField, __instance, toColor.Value);
+        }
+    }
+}

--- a/Chroma/HarmonyPatches/Events/GlsColorChromafier.cs
+++ b/Chroma/HarmonyPatches/Events/GlsColorChromafier.cs
@@ -23,19 +23,19 @@ namespace Chroma.HarmonyPatches.Events;
 internal class GlsColorChromafier : IAffinity, IInitializable
 {
     private static readonly FieldInfo FromColorField =
-        typeof(LightColorGroupEffect).GetField("_fromColor", BindingFlags.Instance | BindingFlags.NonPublic);
+        typeof(LightColorGroupEffect).GetField("_fromColor", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
     private static readonly FieldInfo ToColorField =
-        typeof(LightColorGroupEffect).GetField("_toColor", BindingFlags.Instance | BindingFlags.NonPublic);
+        typeof(LightColorGroupEffect).GetField("_toColor", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
     private static readonly FieldInfo AltFromColorField =
-        typeof(LightColorGroupEffect).GetField("_alternativeFromColor", BindingFlags.Instance | BindingFlags.NonPublic);
+        typeof(LightColorGroupEffect).GetField("_alternativeFromColor", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
     private static readonly FieldInfo AltToColorField =
-        typeof(LightColorGroupEffect).GetField("_alternativeToColor", BindingFlags.Instance | BindingFlags.NonPublic);
+        typeof(LightColorGroupEffect).GetField("_alternativeToColor", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
     private static readonly MethodInfo SetColorMethod =
-        typeof(LightColorGroupEffect).GetMethod("SetColor", BindingFlags.Instance | BindingFlags.NonPublic);
+        typeof(LightColorGroupEffect).GetMethod("SetColor", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
     private static readonly object[] NO_TWEEN_INDICATOR = [0f];
 
@@ -54,7 +54,17 @@ internal class GlsColorChromafier : IAffinity, IInitializable
     {
         if (eventData is ICustomData customDataEvent)
         {
-            return customDataEvent.customData.GetColor("color");
+            List<object>? color = customDataEvent.customData.Get<List<object>>("color");
+            if (color == null || color.Count < 3)
+            {
+                return null;
+            }
+
+            return new Color(
+                Convert.ToSingle(color[0]),
+                Convert.ToSingle(color[1]),
+                Convert.ToSingle(color[2]),
+                color.Count > 3 ? Convert.ToSingle(color[3]) : 1f);
         }
 
         return null;
@@ -68,7 +78,11 @@ internal class GlsColorChromafier : IAffinity, IInitializable
     {
         Color? fromColor = ResolveCustomColor(currentEventData);
         var nextEventData = currentEventData.nextSameTypeEventData as LightColorBeatmapEventData;
+#if PRE_V1_37_1
+        bool hasTween = nextEventData != null && nextEventData.transitionType != BeatmapEventTransitionType.Instant;
+#else
         bool hasTween = nextEventData != null && nextEventData.easeType != EaseType.None;
+#endif
         Color? toColor = hasTween ? ResolveCustomColor(nextEventData!) : fromColor;
 
         if (fromColor.HasValue)

--- a/Chroma/Installers/ChromaPlayerInstaller.cs
+++ b/Chroma/Installers/ChromaPlayerInstaller.cs
@@ -124,6 +124,9 @@ internal class ChromaPlayerInstaller : Installer
             Container.Bind<LightWithIdCustomizer>().AsSingle();
         }
 
+        // GLS color discovery — runs unconditionally (no Chroma map requirement needed)
+        Container.BindInterfacesTo<GlsColorChromafier>().AsSingle();
+
         // Zen mode
         Container.BindInterfacesTo<ObstacleHeadCollisionDisable>().AsSingle();
         Container.BindInterfacesTo<ZenModeBinder>().AsSingle();


### PR DESCRIPTION
DEPENDS ON https://github.com/Aeroluna/CustomJSONData/pull/23/changes
Full end to end GLS chroma RGB and customdata support.

Full end to end demo here, using the build from these two PRs.
https://youtu.be/mUhGttjGO9g
Read the video description for an explanation of everything tested / demonstrated by the video.

Strobe demo not included because I'm lazy and ChroMapper has a bug at the moment preventing strobes from saving properly. They probably work fine

Still finishing up the ChroMapper changes from the end of the video but would be good to get support for this ahead of the ChroMapper GLS launch.

<3