### PR TITLE
Drop `SiraUtilHeadFinder` for 1.40.8+

### DIFF
--- a/Heck/HarmonyPatches/SiraUtilHeadFinder.cs
+++ b/Heck/HarmonyPatches/SiraUtilHeadFinder.cs
@@ -1,4 +1,5 @@
-﻿using SiraUtil.Affinity;
+﻿#if PRE_V1_40_8
+using SiraUtil.Affinity;
 using SiraUtil.Tools.FPFC;
 using UnityEngine;
 
@@ -24,3 +25,4 @@ internal class SiraUtilHeadFinder : IAffinity
         FpfcHeadTransform = null;
     }
 }
+#endif

--- a/Heck/Heck.csproj
+++ b/Heck/Heck.csproj
@@ -19,7 +19,8 @@
     <DependsOn Include="BeatSaberMarkupLanguage" Version="^1.5.9"/>
     <DependsOn Include="BSIPA" Version="^4.2.2"/>
     <DependsOn Include="CustomJSONData" Version="^2.6.1"/>
-    <DependsOn Include="SiraUtil" Version="^3.0.5"/>
+    <DependsOn Include="SiraUtil" Version="^3.0.5" Condition="$(PRE_V1_40_8) != ''"/>
+    <DependsOn Include="SiraUtil" Version="^3.2.0" Condition="$(PRE_V1_40_8) == ''"/>
   </ItemGroup>
 
   <ItemDefinitionGroup>

--- a/Heck/HeckImplementation/BaseProviders/PlayerTransformBaseProvider.cs
+++ b/Heck/HeckImplementation/BaseProviders/PlayerTransformBaseProvider.cs
@@ -51,24 +51,35 @@ internal class PlayerTransformGetter : ITickable
     private readonly PlayerTransformBaseProvider _playerTransformBaseProvider;
     private readonly PlayerTransforms _playerTransforms;
     private readonly PlayerVRControllersManager _playerVRControllersManager;
+
+#if PRE_V1_40_8
     private readonly SiraUtilHeadFinder _siraUtilHeadFinder;
+#endif
 
     [UsedImplicitly]
     private PlayerTransformGetter(
         PlayerTransformBaseProvider playerTransformBaseProvider,
         PlayerTransforms playerTransforms,
-        PlayerVRControllersManager playerVRControllersManager,
-        SiraUtilHeadFinder siraUtilHeadFinder)
+#if PRE_V1_40_8
+        SiraUtilHeadFinder siraUtilHeadFinder,
+#endif
+        PlayerVRControllersManager playerVRControllersManager)
     {
         _playerTransformBaseProvider = playerTransformBaseProvider;
         _playerTransforms = playerTransforms;
         _playerVRControllersManager = playerVRControllersManager;
+#if PRE_V1_40_8
         _siraUtilHeadFinder = siraUtilHeadFinder;
+#endif
     }
 
     public void Tick()
     {
+#if PRE_V1_40_8
         Transform head = _siraUtilHeadFinder.FpfcHeadTransform ?? _playerTransforms._headTransform;
+#else
+        Transform head = _playerTransforms._headTransform;
+#endif
 
         // _playerTransforms._leftHandTransform points to the saber instead of the hand in 1.34+
         Transform leftHand = _playerVRControllersManager.leftHandVRController.transform;

--- a/Heck/Installers/HeckPlayerInstaller.cs
+++ b/Heck/Installers/HeckPlayerInstaller.cs
@@ -30,8 +30,10 @@ internal class HeckPlayerInstaller : Installer
 
         Container.Bind<ObjectInitializerManager>().AsSingle();
 
+#if PRE_V1_40_8
         // Get fpfc head
         Container.BindInterfacesAndSelfTo<SiraUtilHeadFinder>().AsSingle();
+#endif
 
         // Note Cut Sound Fix
         Container.BindInterfacesTo<NoteCutSoundDelayer>().AsSingle();


### PR DESCRIPTION
[`SiraUtilHeadFinder`](https://github.com/Auros/SiraUtil/blob/604b4212999563d82cb78b069fc2953f301b15a6/SiraUtil/Tools/FPFC/GameTransformFPFCListener.cs#L5) is an empty class since SiraUtil v3.2.0 (Beat Saber 1.40.0+). It only exists because this patch still exists here.

This removes the patch for 1.40.8+ builds so the class in SiraUtil can also be removed.