### PR TITLE
Conditionally patch `Clamp` into `BeatmapObjectsInTimeRowProcessor`

### DIFF
--- a/NoodleExtensions/HarmonyPatches/ObjectProcessing/ProcessNotesNoodleDataInTimeRow.cs
+++ b/NoodleExtensions/HarmonyPatches/ObjectProcessing/ProcessNotesNoodleDataInTimeRow.cs
@@ -344,28 +344,49 @@ internal static class ProcessNotesNoodleDataInTimeRow
     private static IEnumerable<CodeInstruction> ProcessColorNotesInTimeRowTranspiler(
         IEnumerable<CodeInstruction> instructions)
     {
-        return new CodeMatcher(instructions)
+        CodeMatcher codeMatcher = new(instructions);
 
-            // clamp
-            /*
-             * -- List<NoteData> list = this._notesInColumnsReusableProcessingListOfLists[noteData.lineIndex];
-             * ++ List<NoteData> list = this._notesInColumnsReusableProcessingListOfLists[Mathf.Clamp(noteData.lineIndex, 0, 3)];
-             */
+        // clamp
+        /*
+         * -- List<NoteData> list = this._notesInColumnsReusableProcessingListOfLists[noteData.lineIndex];
+         * ++ List<NoteData> list = this._notesInColumnsReusableProcessingListOfLists[Mathf.Clamp(noteData.lineIndex, 0, 3)];
+         */
+        codeMatcher
             .MatchForward(
                 true,
                 new CodeMatch(OpCodes.Ldloc_S),
                 new CodeMatch(OpCodes.Callvirt),
-                new CodeMatch(OpCodes.Ldelem_Ref))
-            .Insert(
+                new CodeMatch(OpCodes.Ldelem_Ref));
+
+        if (codeMatcher.IsValid)
+        {
+            codeMatcher.Insert(
                 new CodeInstruction(OpCodes.Ldc_I4_0),
                 new CodeInstruction(OpCodes.Ldc_I4_3),
-                new CodeInstruction(OpCodes.Call, _clampMethod))
+                new CodeInstruction(OpCodes.Call, _clampMethod));
+        }
+        else
+        {
+            // check if someone else has already patched a Clamp in
+            codeMatcher
+                .Start()
+                .MatchForward(
+                    true,
+                    new CodeMatch(OpCodes.Ldloc_S),
+                    new CodeMatch(OpCodes.Callvirt),
+                    new CodeMatch(OpCodes.Ldc_I4_0),
+                    new CodeMatch(OpCodes.Ldc_I4_3),
+                    new CodeMatch(i => (i.opcode == OpCodes.Call || i.opcode == OpCodes.Callvirt) && i.operand is MethodBase method && method.DeclaringType.FullName is "System.Math" or "UnityEngine.Mathf" && method.Name == nameof(Mathf.Clamp)),
+                    new CodeMatch(OpCodes.Ldelem_Ref))
+                .ThrowIfInvalid("Failed to apply Clamp patch");
+        }
 
-            // yeet slider processing
-            /*
-             * ++ return;
-             * foreach (SliderData sliderData in enumerable2)
-             */
+        // yeet slider processing
+        /*
+         * ++ return;
+         * foreach (SliderData sliderData in enumerable2)
+         */
+        return codeMatcher
             .MatchForward(
                 false,
                 new CodeMatch(OpCodes.Ldloc_1),


### PR DESCRIPTION
There are now multiple mods (MappingExtensions, NoodleExtensions, SongPlayHistory, ScorePercentage, possibly others) that attempt to patch `Mathf.Clamp(noteData.lineIndex, 0, 3)` into `HandleCurrentTimeSliceAllNotesAndSlidersDidFinishTimeSlice`. When these other mods are installed, NoodleExtension breaks level loading with this error:

<details>
<summary>Log Snippet</summary>

```log
[ERROR | Harmony] Failed to patch void BeatmapObjectsInTimeRowProcessor::HandleCurrentTimeSliceAllNotesAndSlidersDidFinishTimeSlice(BeatmapObjectsInTimeRowProcessor+TimeSliceContainer<BeatmapDataItem> allObjectsTimeSlice, float nextTimeSliceTime): System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.InvalidOperationException: Cannot insert instructions at invalid position.
[ERROR | Harmony]   at HarmonyLib.CodeMatcher.Insert (HarmonyLib.CodeInstruction[] instructions) [0x00008] in <b35c811570944de4b3c41dc8bca68b94>:0 
[ERROR | Harmony]   at NoodleExtensions.HarmonyPatches.ObjectProcessing.ProcessNotesNoodleDataInTimeRow.ProcessColorNotesInTimeRowTranspiler (System.Collections.Generic.IEnumerable`1[T] instructions) [0x00082] in <829e4c7cdb364e4d952933648fc9d26f>:0 
[ERROR | Harmony]   at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
[ERROR | Harmony]   at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <13c0c460649d4ce49f991e2c222fa635>:0 
[ERROR | Harmony]    --- End of inner exception stack trace ---
[ERROR | Harmony]   at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00083] in <13c0c460649d4ce49f991e2c222fa635>:0 
[ERROR | Harmony]   at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in <13c0c460649d4ce49f991e2c222fa635>:0 
[ERROR | Harmony]   at HarmonyLib.Internal.Patching.ILManipulator.ApplyTranspilers (System.Reflection.Emit.ILGenerator il, System.Reflection.MethodBase original, System.Func`2[T,TResult] getLocal, System.Func`1[TResult] defineLabel) [0x00093] in <b35c811570944de4b3c41dc8bca68b94>:0 
[ERROR | Harmony]   at HarmonyLib.Internal.Patching.ILManipulator.WriteTo (Mono.Cecil.Cil.MethodBody body, System.Reflection.MethodBase original) [0x00066] in <b35c811570944de4b3c41dc8bca68b94>:0 
[ERROR | Harmony]   at HarmonyLib.Public.Patching.HarmonyManipulator.WriteTranspilers () [0x00084] in <b35c811570944de4b3c41dc8bca68b94>:0 
[ERROR | Harmony]   at HarmonyLib.Public.Patching.HarmonyManipulator.WriteImpl () [0x00031] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ### Exception from user "aeroluna.NoodleExtensionsFeatures", Harmony v2.16.0.0
[DEBUG | Harmony] ### Original: void BeatmapObjectsInTimeRowProcessor::HandleCurrentTimeSliceAllNotesAndSlidersDidFinishTimeSlice(BeatmapObjectsInTimeRowProcessor+TimeSliceContainer<BeatmapDataItem> allObjectsTimeSlice, float nextTimeSliceTime)
[DEBUG | Harmony] ### Patch class: NoodleExtensions.HarmonyPatches.ObjectProcessing.ProcessNotesNoodleDataInTimeRow
[DEBUG | Harmony] ### HarmonyLib.HarmonyException: IL Compile Error (unknown location) ---> HarmonyLib.HarmonyException: IL Compile Error (unknown location) ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.InvalidOperationException: Cannot insert instructions at invalid position.
[DEBUG | Harmony] ###   at HarmonyLib.CodeMatcher.Insert (HarmonyLib.CodeInstruction[] instructions) [0x00008] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at NoodleExtensions.HarmonyPatches.ObjectProcessing.ProcessNotesNoodleDataInTimeRow.ProcessColorNotesInTimeRowTranspiler (System.Collections.Generic.IEnumerable`1[T] instructions) [0x00082] in <829e4c7cdb364e4d952933648fc9d26f>:0 
[DEBUG | Harmony] ###   at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
[DEBUG | Harmony] ###   at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <13c0c460649d4ce49f991e2c222fa635>:0 
[DEBUG | Harmony] ###    --- End of inner exception stack trace ---
[DEBUG | Harmony] ###   at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00083] in <13c0c460649d4ce49f991e2c222fa635>:0 
[DEBUG | Harmony] ###   at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in <13c0c460649d4ce49f991e2c222fa635>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Internal.Patching.ILManipulator.ApplyTranspilers (System.Reflection.Emit.ILGenerator il, System.Reflection.MethodBase original, System.Func`2[T,TResult] getLocal, System.Func`1[TResult] defineLabel) [0x00093] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Internal.Patching.ILManipulator.WriteTo (Mono.Cecil.Cil.MethodBody body, System.Reflection.MethodBase original) [0x00066] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.HarmonyManipulator.WriteTranspilers () [0x00084] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.HarmonyManipulator.WriteImpl () [0x00031] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###    --- End of inner exception stack trace ---
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.HarmonyManipulator.WriteImpl () [0x003e9] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.HarmonyManipulator.Process (MonoMod.Cil.ILContext ilContext, System.Reflection.MethodBase originalMethod) [0x00042] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.HarmonyManipulator.Manipulate (System.Reflection.MethodBase original, HarmonyLib.PatchInfo patchInfo, MonoMod.Cil.ILContext ctx) [0x00007] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.HarmonyManipulator.Manipulate (System.Reflection.MethodBase original, MonoMod.Cil.ILContext ctx) [0x00007] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.ManagedMethodPatcher.Manipulator (MonoMod.Cil.ILContext ctx) [0x00012] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at MonoMod.Cil.ILContext.Invoke (MonoMod.Cil.ILContext+Manipulator manip) [0x00092] in <a9e72e137d444829a51f515c4ce72a23>:0 
[DEBUG | Harmony] ###   at MonoMod.RuntimeDetour.DetourManager+ManagedDetourState.InvokeManipulator (MonoMod.RuntimeDetour.DetourManager+ILHookEntry entry, Mono.Cecil.MethodDefinition def) [0x0001c] in <39d07baf0f68488db889cb7a24b13288>:0 
[DEBUG | Harmony] ###   at MonoMod.RuntimeDetour.DetourManager+ManagedDetourState.UpdateEndOfChain () [0x000b6] in <39d07baf0f68488db889cb7a24b13288>:0 
[DEBUG | Harmony] ###   at MonoMod.RuntimeDetour.DetourManager+ManagedDetourState.AddILHook (MonoMod.RuntimeDetour.DetourManager+SingleILHookState ilhook, System.Boolean takeLock) [0x000e9] in <39d07baf0f68488db889cb7a24b13288>:0 
[DEBUG | Harmony] ###   at MonoMod.RuntimeDetour.ILHook.Apply () [0x00052] in <39d07baf0f68488db889cb7a24b13288>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.ManagedMethodPatcher.DetourTo (System.Reflection.MethodBase replacement) [0x00032] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###    --- End of inner exception stack trace ---
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.ManagedMethodPatcher.DetourTo (System.Reflection.MethodBase replacement) [0x0004c] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.PatchFunctions.UpdateWrapper (System.Reflection.MethodBase original, HarmonyLib.PatchInfo patchInfo) [0x00033] in <b35c811570944de4b3c41dc8bca68b94>:0
[DEBUG | Harmony] ### Exception from user "aeroluna.NoodleExtensionsFeatures", Harmony v2.16.0.0
[DEBUG | Harmony] ### Original: void BeatmapObjectsInTimeRowProcessor::HandleCurrentTimeSliceAllNotesAndSlidersDidFinishTimeSlice(BeatmapObjectsInTimeRowProcessor+TimeSliceContainer<BeatmapDataItem> allObjectsTimeSlice, float nextTimeSliceTime)
[DEBUG | Harmony] ### Patch class: NoodleExtensions.HarmonyPatches.ObjectProcessing.ProcessNotesNoodleDataInTimeRow
[DEBUG | Harmony] ### HarmonyLib.HarmonyException: IL Compile Error (unknown location) ---> HarmonyLib.HarmonyException: IL Compile Error (unknown location) ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.InvalidOperationException: Cannot insert instructions at invalid position.
[DEBUG | Harmony] ###   at HarmonyLib.CodeMatcher.Insert (HarmonyLib.CodeInstruction[] instructions) [0x00008] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at NoodleExtensions.HarmonyPatches.ObjectProcessing.ProcessNotesNoodleDataInTimeRow.ProcessColorNotesInTimeRowTranspiler (System.Collections.Generic.IEnumerable`1[T] instructions) [0x00082] in <829e4c7cdb364e4d952933648fc9d26f>:0 
[DEBUG | Harmony] ###   at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
[DEBUG | Harmony] ###   at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <13c0c460649d4ce49f991e2c222fa635>:0 
[DEBUG | Harmony] ###    --- End of inner exception stack trace ---
[DEBUG | Harmony] ###   at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00083] in <13c0c460649d4ce49f991e2c222fa635>:0 
[DEBUG | Harmony] ###   at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in <13c0c460649d4ce49f991e2c222fa635>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Internal.Patching.ILManipulator.ApplyTranspilers (System.Reflection.Emit.ILGenerator il, System.Reflection.MethodBase original, System.Func`2[T,TResult] getLocal, System.Func`1[TResult] defineLabel) [0x00093] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Internal.Patching.ILManipulator.WriteTo (Mono.Cecil.Cil.MethodBody body, System.Reflection.MethodBase original) [0x00066] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.HarmonyManipulator.WriteTranspilers () [0x00084] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.HarmonyManipulator.WriteImpl () [0x00031] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###    --- End of inner exception stack trace ---
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.HarmonyManipulator.WriteImpl () [0x003e9] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.HarmonyManipulator.Process (MonoMod.Cil.ILContext ilContext, System.Reflection.MethodBase originalMethod) [0x00042] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.HarmonyManipulator.Manipulate (System.Reflection.MethodBase original, HarmonyLib.PatchInfo patchInfo, MonoMod.Cil.ILContext ctx) [0x00007] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.HarmonyManipulator.Manipulate (System.Reflection.MethodBase original, MonoMod.Cil.ILContext ctx) [0x00007] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.ManagedMethodPatcher.Manipulator (MonoMod.Cil.ILContext ctx) [0x00012] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at MonoMod.Cil.ILContext.Invoke (MonoMod.Cil.ILContext+Manipulator manip) [0x00092] in <a9e72e137d444829a51f515c4ce72a23>:0 
[DEBUG | Harmony] ###   at MonoMod.RuntimeDetour.DetourManager+ManagedDetourState.InvokeManipulator (MonoMod.RuntimeDetour.DetourManager+ILHookEntry entry, Mono.Cecil.MethodDefinition def) [0x0001c] in <39d07baf0f68488db889cb7a24b13288>:0 
[DEBUG | Harmony] ###   at MonoMod.RuntimeDetour.DetourManager+ManagedDetourState.UpdateEndOfChain () [0x000b6] in <39d07baf0f68488db889cb7a24b13288>:0 
[DEBUG | Harmony] ###   at MonoMod.RuntimeDetour.DetourManager+ManagedDetourState.AddILHook (MonoMod.RuntimeDetour.DetourManager+SingleILHookState ilhook, System.Boolean takeLock) [0x000e9] in <39d07baf0f68488db889cb7a24b13288>:0 
[DEBUG | Harmony] ###   at MonoMod.RuntimeDetour.ILHook.Apply () [0x00052] in <39d07baf0f68488db889cb7a24b13288>:0 
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.ManagedMethodPatcher.DetourTo (System.Reflection.MethodBase replacement) [0x00032] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###    --- End of inner exception stack trace ---
[DEBUG | Harmony] ###   at HarmonyLib.Public.Patching.ManagedMethodPatcher.DetourTo (System.Reflection.MethodBase replacement) [0x0004c] in <b35c811570944de4b3c41dc8bca68b94>:0 
[DEBUG | Harmony] ###   at HarmonyLib.PatchFunctions.UpdateWrapper (System.Reflection.MethodBase original, HarmonyLib.PatchInfo patchInfo) [0x00033] in <b35c811570944de4b3c41dc8bca68b94>:0
[CRITICAL | Heck/ModuleManager] Exception while loading [NoodleExtensions]
[CRITICAL | UnityEngine] InvalidOperationException: Cannot insert instructions at invalid position.
[CRITICAL | UnityEngine] HarmonyLib.CodeMatcher.Insert (HarmonyLib.CodeInstruction[] instructions) (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] NoodleExtensions.HarmonyPatches.ObjectProcessing.ProcessNotesNoodleDataInTimeRow.ProcessColorNotesInTimeRowTranspiler (System.Collections.Generic.IEnumerable`1[T] instructions) (at <829e4c7cdb364e4d952933648fc9d26f>:0)
[CRITICAL | UnityEngine] System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <13c0c460649d4ce49f991e2c222fa635>:0)
[CRITICAL | UnityEngine] Rethrow as TargetInvocationException: Exception has been thrown by the target of an invocation.
[CRITICAL | UnityEngine] System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <13c0c460649d4ce49f991e2c222fa635>:0)
[CRITICAL | UnityEngine] System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) (at <13c0c460649d4ce49f991e2c222fa635>:0)
[CRITICAL | UnityEngine] HarmonyLib.Internal.Patching.ILManipulator.ApplyTranspilers (System.Reflection.Emit.ILGenerator il, System.Reflection.MethodBase original, System.Func`2[T,TResult] getLocal, System.Func`1[TResult] defineLabel) (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] HarmonyLib.Internal.Patching.ILManipulator.WriteTo (Mono.Cecil.Cil.MethodBody body, System.Reflection.MethodBase original) (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] HarmonyLib.Public.Patching.HarmonyManipulator.WriteTranspilers () (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] HarmonyLib.Public.Patching.HarmonyManipulator.WriteImpl () (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] Rethrow as HarmonyException: IL Compile Error (unknown location)
[CRITICAL | UnityEngine] HarmonyLib.Public.Patching.HarmonyManipulator.WriteImpl () (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] HarmonyLib.Public.Patching.HarmonyManipulator.Process (MonoMod.Cil.ILContext ilContext, System.Reflection.MethodBase originalMethod) (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] HarmonyLib.Public.Patching.HarmonyManipulator.Manipulate (System.Reflection.MethodBase original, HarmonyLib.PatchInfo patchInfo, MonoMod.Cil.ILContext ctx) (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] HarmonyLib.Public.Patching.HarmonyManipulator.Manipulate (System.Reflection.MethodBase original, MonoMod.Cil.ILContext ctx) (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] HarmonyLib.Public.Patching.ManagedMethodPatcher.Manipulator (MonoMod.Cil.ILContext ctx) (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] MonoMod.Cil.ILContext.Invoke (MonoMod.Cil.ILContext+Manipulator manip) (at <a9e72e137d444829a51f515c4ce72a23>:0)
[CRITICAL | UnityEngine] MonoMod.RuntimeDetour.DetourManager+ManagedDetourState.InvokeManipulator (MonoMod.RuntimeDetour.DetourManager+ILHookEntry entry, Mono.Cecil.MethodDefinition def) (at <39d07baf0f68488db889cb7a24b13288>:0)
[CRITICAL | UnityEngine] MonoMod.RuntimeDetour.DetourManager+ManagedDetourState.UpdateEndOfChain () (at <39d07baf0f68488db889cb7a24b13288>:0)
[CRITICAL | UnityEngine] MonoMod.RuntimeDetour.DetourManager+ManagedDetourState.AddILHook (MonoMod.RuntimeDetour.DetourManager+SingleILHookState ilhook, System.Boolean takeLock) (at <39d07baf0f68488db889cb7a24b13288>:0)
[CRITICAL | UnityEngine] MonoMod.RuntimeDetour.ILHook.Apply () (at <39d07baf0f68488db889cb7a24b13288>:0)
[CRITICAL | UnityEngine] HarmonyLib.Public.Patching.ManagedMethodPatcher.DetourTo (System.Reflection.MethodBase replacement) (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] Rethrow as HarmonyException: IL Compile Error (unknown location)
[CRITICAL | UnityEngine] HarmonyLib.Public.Patching.ManagedMethodPatcher.DetourTo (System.Reflection.MethodBase replacement) (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] HarmonyLib.PatchFunctions.UpdateWrapper (System.Reflection.MethodBase original, HarmonyLib.PatchInfo patchInfo) (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] Rethrow as HarmonyException: IL Compile Error (unknown location)
[CRITICAL | UnityEngine] HarmonyLib.PatchClassProcessor.ReportException (System.Exception exception, System.Reflection.MethodBase original) (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] HarmonyLib.PatchClassProcessor.Patch () (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] HarmonyLib.Harmony.PatchAll (System.Type type) (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] HarmonyLib.CollectionExtensions.Do[T] (System.Collections.Generic.IEnumerable`1[T] sequence, System.Action`1[T] action) (at <b35c811570944de4b3c41dc8bca68b94>:0)
[CRITICAL | UnityEngine] Heck.Patcher.HeckPatcher.set_Enabled (System.Boolean value) (at C:/Users/Nicolas/Source/Repos/Heck/Heck/Services/Patcher/HeckPatcher.cs:63)
[CRITICAL | UnityEngine] Heck.Module.ModuleManager.<Activate>g__Finish|5_3 (System.Boolean success, Heck.Module.ModuleManager+<>c__DisplayClass5_0& , Heck.Module.ModuleManager+<>c__DisplayClass5_1& ) (at C:/Users/Nicolas/Source/Repos/Heck/Heck/Services/Module/ModuleManager.cs:310)
[CRITICAL | UnityEngine] Heck.Module.ModuleManager.<Activate>g__InitializeModule|5_2 (Heck.Module.ModuleData module, System.Boolean depended, Heck.Module.ModuleManager+<>c__DisplayClass5_0& ) (at C:/Users/Nicolas/Source/Repos/Heck/Heck/Services/Module/ModuleManager.cs:288)
[CRITICAL | UnityEngine] Heck.Module.ModuleManager.Activate (BeatmapKey& beatmapKey, BeatmapLevel beatmapLevel, Heck.Module.LevelType levelType, OverrideEnvironmentSettings& overrideEnvironmentSettings) (at C:/Users/Nicolas/Source/Repos/Heck/Heck/Services/Module/ModuleManager.cs:195)
[CRITICAL | UnityEngine] Heck.HarmonyPatches.ModuleActivator.StandardModuleActivator.StandardPrefix (BeatmapKey& beatmapKey, BeatmapLevel beatmapLevel, OverrideEnvironmentSettings& overrideEnvironmentSettings) (at C:/Users/Nicolas/Source/Repos/Heck/Heck/HarmonyPatches/ModuleActivator/StandardModuleActivator.cs:38)
[CRITICAL | UnityEngine] (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition.DMD<DMD<>?-1125607980::StandardLevelScenesTransitionSetupDataSO::Init>(StandardLevelScenesTransitionSetupDataSO,string,BeatmapKey&,BeatmapLevel,OverrideEnvironmentSettings,ColorScheme,bool,GameplayModifiers,PlayerSpecificSettings,PracticeSettings,EnvironmentsListModel,AudioClipAsyncLoader,SettingsManager,GameplayAdditionalInformation,BeatmapDataLoader,BeatmapLevelsEntitlementModel,BeatmapLevelsModel,IBeatmapLevelData,System.Nullable`1<RecordingToolManager/SetupData>)
[CRITICAL | UnityEngine] (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition.SyncProxy<System.Void StandardLevelScenesTransitionSetupDataSO:Init(System.String, BeatmapKey&, BeatmapLevel, OverrideEnvironmentSettings, ColorScheme, System.Boolean, GameplayModifiers, PlayerSpecificSettings, PracticeSettings, EnvironmentsListModel, AudioClipAsyncLoader, SettingsManager, GameplayAdditionalInformation, BeatmapDataLoader, BeatmapLevelsEntitlementModel, BeatmapLevelsModel, IBeatmapLevelData, System.Nullable`1[[RecordingToolManager+SetupData, Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]])>(StandardLevelScenesTransitionSetupDataSO,string,BeatmapKey&,BeatmapLevel,OverrideEnvironmentSettings,ColorScheme,bool,GameplayModifiers,PlayerSpecificSettings,PracticeSettings,EnvironmentsListModel,AudioClipAsyncLoader,SettingsManager,GameplayAdditionalInformation,BeatmapDataLoader,BeatmapLevelsEntitlementModel,BeatmapLevelsModel,IBeatmapLevelData,System.Nullable`1<RecordingToolManager/SetupData>)
[CRITICAL | UnityEngine] (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition.DMD<DMD<>?615163186::MenuTransitionsHelper::StartStandardLevel>(MenuTransitionsHelper,string,BeatmapKey&,BeatmapLevel,OverrideEnvironmentSettings,ColorScheme,bool,GameplayModifiers,PlayerSpecificSettings,PracticeSettings,EnvironmentsListModel,GameplayAdditionalInformation,System.Action,System.Action`1<Zenject.DiContainer>,System.Action`2<StandardLevelScenesTransitionSetupDataSO, LevelCompletionResults>,System.Action`2<StandardLevelScenesTransitionSetupDataSO, LevelCompletionResults>,IBeatmapLevelData,System.Nullable`1<RecordingToolManager/SetupData>)
[CRITICAL | UnityEngine] (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition.SyncProxy<System.Void MenuTransitionsHelper:StartStandardLevel(System.String, BeatmapKey&, BeatmapLevel, OverrideEnvironmentSettings, ColorScheme, System.Boolean, GameplayModifiers, PlayerSpecificSettings, PracticeSettings, EnvironmentsListModel, GameplayAdditionalInformation, System.Action, System.Action`1[[Zenject.DiContainer, Zenject, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Action`2[[StandardLevelScenesTransitionSetupDataSO, Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null],[LevelCompletionResults, GameplayCore, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Action`2[[StandardLevelScenesTransitionSetupDataSO, Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null],[LevelCompletionResults, GameplayCore, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], IBeatmapLevelData, System.Nullable`1[[RecordingToolManager+SetupData, Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]])>(MenuTransitionsHelper,string,BeatmapKey&,BeatmapLevel,OverrideEnvironmentSettings,ColorScheme,bool,GameplayModifiers,PlayerSpecificSettings,PracticeSettings,EnvironmentsListModel,GameplayAdditionalInformation,System.Action,System.Action`1<Zenject.DiContainer>,System.Action`2<StandardLevelScenesTransitionSetupDataSO, LevelCompletionResults>,System.Action`2<StandardLevelScenesTransitionSetupDataSO, LevelCompletionResults>,IBeatmapLevelData,System.Nullable`1<RecordingToolManager/SetupData>)
[CRITICAL | UnityEngine] Heck.PlayView.PlayViewManager.StartStandard () (at C:/Users/Nicolas/Source/Repos/Heck/Heck/Services/PlayView/PlayViewManager.cs:284)
[CRITICAL | UnityEngine] Heck.PlayView.PlayViewManager.<Activate>b__26_0 () (at C:/Users/Nicolas/Source/Repos/Heck/Heck/Services/PlayView/PlayViewManager.cs:246)
[CRITICAL | UnityEngine] Heck.PlayView.PlayViewManager.add_TransitionFinished (System.Action value) (at C:/Users/Nicolas/Source/Repos/Heck/Heck/Services/PlayView/PlayViewManager.cs:71)
[CRITICAL | UnityEngine] Heck.PlayView.PlayViewManager.Activate () (at C:/Users/Nicolas/Source/Repos/Heck/Heck/Services/PlayView/PlayViewManager.cs:211)
[CRITICAL | UnityEngine] Heck.SettingsSetter.SettingsSetterViewController.OnAcceptClick () (at C:/Users/Nicolas/Source/Repos/Heck/Heck/SettingsSetter/SettingsSetterViewController.cs:619)
[CRITICAL | UnityEngine] System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <13c0c460649d4ce49f991e2c222fa635>:0)
[CRITICAL | UnityEngine] Rethrow as TargetInvocationException: Exception has been thrown by the target of an invocation.
[CRITICAL | UnityEngine] System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <13c0c460649d4ce49f991e2c222fa635>:0)
[CRITICAL | UnityEngine] System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) (at <13c0c460649d4ce49f991e2c222fa635>:0)
[CRITICAL | UnityEngine] BeatSaberMarkupLanguage.Parser.BSMLAction.Invoke (System.Object[] parameters) (at BeatSaberMarkupLanguage/Parser/BSMLAction.cs:24)
[CRITICAL | UnityEngine] BeatSaberMarkupLanguage.TypeHandlers.ButtonHandler+<>c__DisplayClass5_0.<HandleType>b__0 () (at BeatSaberMarkupLanguage/TypeHandlers/ButtonHandler.cs:40)
[CRITICAL | UnityEngine] UnityEngine.Events.InvokableCall.Invoke () (at <d039b0cb9805419f9a37cad23f1ba354>:0)
[CRITICAL | UnityEngine] UnityEngine.Events.UnityEvent.Invoke () (at <d039b0cb9805419f9a37cad23f1ba354>:0)
[CRITICAL | UnityEngine] UnityEngine.UI.Button.Press () (at <4ff6ef5ae25b40de946ee59e1824dda9>:0)
[CRITICAL | UnityEngine] UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData) (at <4ff6ef5ae25b40de946ee59e1824dda9>:0)
[CRITICAL | UnityEngine] UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData) (at <4ff6ef5ae25b40de946ee59e1824dda9>:0)
[CRITICAL | UnityEngine] UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor) (at <4ff6ef5ae25b40de946ee59e1824dda9>:0)
[CRITICAL | UnityEngine] UnityEngine.EventSystems.ExecuteEvents:Execute(GameObject, BaseEventData, EventFunction`1)
[CRITICAL | UnityEngine] VRUIControls.VRInputModule:ProcessMousePress(MouseButtonEventData)
[CRITICAL | UnityEngine] VRUIControls.VRInputModule:Process()
[CRITICAL | UnityEngine] UnityEngine.EventSystems.EventSystem:Update()
```

</details>

This change makes NoodleExtensions not conflict with them.

I admit this isn't a great solution. I am partly opening this to start a conversation around how we should handle this method. Maybe other mods should instead do `loadAfter: ["NoodleExtensions"]` and figure out themselves if they shouldn't patch this method. Maybe it should be in a shared library. Maybe this is fine. I don't have the answer, but we need a solution.